### PR TITLE
Fix systemd units creation only when proxmox-ve is enabled

### DIFF
--- a/modules/proxmox-ve/cluster.nix
+++ b/modules/proxmox-ve/cluster.nix
@@ -1,6 +1,11 @@
-{ pkgs, ... }:
-
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+lib.mkIf config.services.proxmox-ve.enable {
   systemd.services = {
     pve-cluster = {
       description = "The Proxmox VE cluster filesystem";

--- a/modules/proxmox-ve/container.nix
+++ b/modules/proxmox-ve/container.nix
@@ -1,6 +1,11 @@
-{ pkgs, ... }:
-
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+lib.mkIf config.services.proxmox-ve.enable {
   systemd.services = {
     pve-lxc-syscalld = {
       description = "Proxmox VE LXC Syscall Daemon";

--- a/modules/proxmox-ve/firewall.nix
+++ b/modules/proxmox-ve/firewall.nix
@@ -1,6 +1,11 @@
-{ pkgs, ... }:
-
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+lib.mkIf config.services.proxmox-ve.enable {
   systemd.services = {
     pve-firewall = {
       description = "Proxmox VE firewall";

--- a/modules/proxmox-ve/ha-manager.nix
+++ b/modules/proxmox-ve/ha-manager.nix
@@ -1,6 +1,11 @@
-{ pkgs, ... }:
-
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+lib.mkIf config.services.proxmox-ve.enable {
   systemd.services = {
     pve-ha-lrm = {
       description = "PVE Local HA Resource Manager Daemon";

--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -1,6 +1,11 @@
-{ pkgs, ... }:
-
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+lib.mkIf config.services.proxmox-ve.enable {
   systemd.services = {
     pvedaemon = {
       description = "PVE API Daemon";


### PR DESCRIPTION
This fixes the bug introduced by https://github.com/SaumonNet/proxmox-nixos/pull/25.