### PR TITLE
ref: override src novnc for pve-novnc, to 1.4.0 from nixpkgs 1.5.0

### DIFF
--- a/pkgs/pve-novnc/default.nix
+++ b/pkgs/pve-novnc/default.nix
@@ -10,6 +10,12 @@ novnc.overrideAttrs (old: rec {
     hash = "sha256-5U2hSBNJVjG5/kkiEnicKOeEgVYmIJE0OIZRpslvXXg=";
   };
 
+  src = fetchgit {
+    url = "https://github.com/novnc/novnc";
+    rev = "v1.4.0";
+    hash = "sha256-G7Rtv7pQFR9UrzhYXDyBf+FRqtjo5NAXU7m/HeXhI1k=";
+  };
+
   patches =
     let
       series = builtins.readFile "${src_patches}/debian/patches/series";


### PR DESCRIPTION
Should close #37. Upstream novnc-pve patches were failing to apply on latest Nixpkgs unstable as the Nixpkgs novnc was bumped from 1.4.0 to 1.5.0 (https://github.com/NixOS/nixpkgs/commit/5f35127c52ae96115895d7e817e7ecd6d289c47a)

Because the upstream novnc submodule is set to 1.4.0, I believe it is appropriate to lock to the same revision as upstream and wait for proxmox to update their novnc patches.