### PR TITLE
Revert "fix: building on unstable using stable qemu"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,21 +50,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1719426051,
-        "narHash": "sha256-yJL9VYQhaRM7xs0M867ZFxwaONB9T2Q4LnGo1WovuR4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "89c49874fb15f4124bf71ca5f42a04f2ee5825fd",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-24.05",
-        "type": "indirect"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1718208800,
@@ -85,7 +70,7 @@
         "crane": "crane",
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-stable": "nixpkgs-stable",
+        "unstable": "unstable",
         "utils": "utils"
       }
     },
@@ -102,6 +87,21 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
+      }
+    },
+    "unstable": {
+      "locked": {
+        "lastModified": 1718318537,
+        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
       }
     },
     "utils": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,6 +1,5 @@
 {
   pkgs,
-  pkgs-stable,
   craneLib ? { },
   ...
 }:
@@ -48,7 +47,7 @@ let
     pve-http-server = callPackage ./pve-http-server { };
     pve-manager = callPackage ./pve-manager { };
     pve-novnc = callPackage ./pve-novnc { };
-    pve-qemu = callPackage ./pve-qemu { qemu_8 = pkgs-stable.qemu; };
+    pve-qemu = callPackage ./pve-qemu { };
     pve-qemu-server = callPackage ./pve-qemu-server { };
     pve-rados2 = callPackage ./pve-rados2 { };
     pve-rs = callPackage ./pve-rs { };

--- a/pkgs/pve-qemu/default.nix
+++ b/pkgs/pve-qemu/default.nix
@@ -1,5 +1,5 @@
 {
-  qemu_8,
+  qemu,
   fetchgit,
   fetchurl,
   proxmox-backup-qemu,
@@ -8,7 +8,7 @@
 }:
 
 (
-  (qemu_8.overrideAttrs (old: rec {
+  (qemu.overrideAttrs (old: rec {
     version = "8.1.5";
 
     src = fetchurl {


### PR DESCRIPTION
Reverts SaumonNet/proxmox-nixos#32

We will not support overriding nixpkgs on the long run, so this code is not necessary anymore. 
This PR broke our automatic updates (see https://proxmox-nixos-update-logs.saumon.network/datadumper/2024-07-11.log)