### PR TITLE
 fix: actually use nixpkgs-stable for overriden packages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Below is a fragment of a NixOS configuration that enables Proxmox VE.
   };
 }
 ```
-⚠️ Do not override the `nixpkgs` input of the flake, as the only tested and supported version of Proxmox-NixOS is with the upstream `nixpkgs`.
+⚠️ Do not override the `nixpkgs-stable` input of the flake, as the only tested and supported version of Proxmox-NixOS is with the upstream stable NixOS release.
 
 ## 🌐 Networking
 

--- a/flake.lock
+++ b/flake.lock
@@ -50,7 +50,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs-stable": {
       "locked": {
         "lastModified": 1718208800,
         "narHash": "sha256-US1tAChvPxT52RV8GksWZS415tTS7PV42KTc2PNDBmc=",
@@ -69,8 +69,7 @@
       "inputs": {
         "crane": "crane",
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs_2",
-        "unstable": "unstable",
+        "nixpkgs-stable": "nixpkgs-stable",
         "utils": "utils"
       }
     },
@@ -87,21 +86,6 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
-      }
-    },
-    "unstable": {
-      "locked": {
-        "lastModified": 1718318537,
-        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
       }
     },
     "utils": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
               (import ./pkgs {
                 inherit craneLib;
                 pkgs = prev;
+                pkgs-stable = pkgs;
               })
               // {
                 nixos-proxmox-ve-iso =

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-24.05";
-    unstable.url = "nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "nixpkgs/nixos-24.05";
     utils.url = "github:numtide/flake-utils";
     flake-compat.url = "github:edolstra/flake-compat";
     crane.url = "github:ipetkov/crane/v0.17.3";
@@ -15,14 +14,13 @@
   outputs =
     {
       self,
-      nixpkgs,
-      unstable,
+      nixpkgs-stable,
       utils,
       crane,
       ...
     }:
     let
-      inherit (nixpkgs) lib;
+      inherit (nixpkgs-stable) lib;
     in
     {
       nixosModules = import ./modules;
@@ -36,7 +34,7 @@
         (
           system:
           let
-            pkgs = import nixpkgs {
+            pkgs = import nixpkgs-stable {
               inherit system;
               overlays = [ self.overlays.${system} ];
             };
@@ -45,11 +43,7 @@
           {
             overlays =
               _: prev:
-              {
-                inherit lib;
-                unstable = unstable.legacyPackages.${system};
-              }
-              // (import ./pkgs {
+              (import ./pkgs {
                 inherit craneLib;
                 pkgs = prev;
               })
@@ -60,7 +54,7 @@
                     pkgs = prev;
                     inherit system;
                     modules = [
-                      "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+                      "${nixpkgs-stable}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
                       (_: {
                         services.proxmox-ve.enable = true;
                         isoImage.isoBaseName = "nixos-proxmox-ve";
@@ -75,7 +69,7 @@
                   extraModules = lib.attrValues self.nixosModules;
                   inherit pkgs system;
                   modules = [
-                    "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+                    "${nixpkgs-stable}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
                     (_: {
                       services.proxmox-ve.enable = true;
                       isoImage.isoBaseName = "nixos-proxmox-ve";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,10 +1,15 @@
 {
   pkgs,
+  pkgs-stable ? pkgs,
   craneLib ? { },
   ...
 }:
 let
-  callPackage = pkgs.lib.callPackageWith (pkgs // ours);
+  callPackage = pkgs.lib.callPackageWith (pkgs // ours // {
+    # Any package that is used for override should be listed here to make this flake
+    # work on anything other than nixos release.
+    inherit (pkgs-stable) qemu novnc;
+  });
   ours = {
     inherit craneLib;
 

--- a/tasks/update.nix
+++ b/tasks/update.nix
@@ -22,7 +22,7 @@ let
       (
         let
           lock = builtins.fromJSON (builtins.readFile ../flake.lock);
-          nixpkgsName = lock.nodes.root.inputs.nixpkgs;
+          nixpkgsName = lock.nodes.root.inputs.nixpkgs-stable;
         in
         fetchTarball {
           url = "https://github.com/NixOS/nixpkgs/archive/${lock.nodes.${nixpkgsName}.locked.rev}.tar.gz";


### PR DESCRIPTION
Based on top of #43 

Fixes: #38 #32 #37 #31

This time it shouldn't cause any problems for maintenance, as the implementation is kept mostly the same as before, only thing that may need maintenance is list of packages used for overrides (in `callPackage = pkgs.lib.callPackageWith (pkgs // ours // {`), but it only matters for non-release NixOS version, it will behave the same on released NixOS.