### PR TITLE
pve-common: fix PCI device name display

### DIFF
--- a/pkgs/pve-common/0003-pci-id-path.patch
+++ b/pkgs/pve-common/0003-pci-id-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/PVE/SysFSTools.pm b/src/PVE/SysFSTools.pm
+index 57f0ac8..13d0bdf 100644
+--- a/PVE/SysFSTools.pm
++++ b/PVE/SysFSTools.pm
+@@ -14,7 +14,7 @@ my $pciregex = "($domainregex):([a-f0-9]{2}):([a-f0-9]{2})\.([a-f0-9])";
+ my $parse_pci_ids = sub {
+     my $ids = {};
+ 
+-    open(my $fh, '<', "/usr/share/misc/pci.ids")
++    open(my $fh, '<', "@pciutils@/share/pci.ids")
+ 	or return $ids;
+ 
+     my $curvendor;

--- a/pkgs/pve-common/default.nix
+++ b/pkgs/pve-common/default.nix
@@ -9,6 +9,7 @@
   perl536,
   glibc,
   openvswitch,
+  pciutils,
   proxmox-backup-client,
   systemd,
   tzdata,
@@ -87,6 +88,11 @@ perl536.pkgs.toPerlModule (
       })
 
       ./0002-mknod-mknodat.patch
+
+      (substituteAll {
+        src = ./0003-pci-id-path.patch;
+        pciutils = "${pciutils}";
+      })
     ];
 
     propagatedBuildInputs = [


### PR DESCRIPTION
Fix the path of `pci.ids` file, so PCIe device names can be properly shown while adding PCI devices.