### PR TITLE
Add support for LINSTOR to Proxmox VE

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,6 +88,21 @@
         "type": "github"
       }
     },
+    "unstable": {
+      "locked": {
+        "lastModified": 1723637854,
+        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
     "utils": {
       "inputs": {
         "systems": "systems"

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1718208800,
-        "narHash": "sha256-US1tAChvPxT52RV8GksWZS415tTS7PV42KTc2PNDBmc=",
+        "lastModified": 1723556749,
+        "narHash": "sha256-+CHVZnTnIYRLYsARInHYoWkujzcRkLY/gXm3s5bE52o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cc54fb41d13736e92229c21627ea4f22199fee6b",
+        "rev": "4a92571f9207810b559c9eac203d1f4d79830073",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,27 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1723637854,
+        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
         "flake-compat": "flake-compat",
         "nixpkgs-stable": "nixpkgs-stable",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "utils": "utils"
       }
     },
@@ -86,21 +102,6 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
-      }
-    },
-    "unstable": {
-      "locked": {
-        "lastModified": 1723637854,
-        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
       }
     },
     "utils": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     nixpkgs-stable.url = "nixpkgs/nixos-24.05";
+    nixpkgs-unstable.url = "nixpkgs/nixos-unstable";
     utils.url = "github:numtide/flake-utils";
     flake-compat.url = "github:edolstra/flake-compat";
     crane.url = "github:ipetkov/crane/v0.17.3";
@@ -15,6 +16,7 @@
     {
       self,
       nixpkgs-stable,
+      nixpkgs-unstable,
       utils,
       crane,
       ...
@@ -38,24 +40,18 @@
               inherit system;
               overlays = [ self.overlays.${system} ];
             };
+            pkgs-unstable = import nixpkgs-unstable { inherit system; };
             craneLib = crane.mkLib pkgs;
           in
           {
             overlays =
-              final: prev:
-              {
-                inherit lib;
-                unstable = unstable.legacyPackages.${system};
-              }
-              // (import ./pkgs {
-                inherit craneLib;
-                pkgs = final;
-              })
+              final: _:
+              (import ./pkgs { inherit pkgs pkgs-unstable craneLib; })
               // {
                 nixos-proxmox-ve-iso =
                   (lib.nixosSystem {
                     extraModules = lib.attrValues self.nixosModules;
-                    pkgs = prev;
+                    pkgs = final;
                     inherit system;
                     modules = [
                       "${nixpkgs-stable}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
@@ -67,20 +63,22 @@
                   }).config.system.build.isoImage;
               };
 
-            packages = utils.lib.filterPackages system (import ./pkgs { inherit pkgs craneLib; }) // {
-              nixos-proxmox-ve-iso =
-                (lib.nixosSystem {
-                  extraModules = lib.attrValues self.nixosModules;
-                  inherit pkgs system;
-                  modules = [
-                    "${nixpkgs-stable}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
-                    (_: {
-                      services.proxmox-ve.enable = true;
-                      isoImage.isoBaseName = "nixos-proxmox-ve";
-                    })
-                  ];
-                }).config.system.build.isoImage;
-            };
+            packages =
+              utils.lib.filterPackages system (import ./pkgs { inherit pkgs pkgs-unstable craneLib; })
+              // {
+                nixos-proxmox-ve-iso =
+                  (lib.nixosSystem {
+                    extraModules = lib.attrValues self.nixosModules;
+                    inherit pkgs system;
+                    modules = [
+                      "${nixpkgs-stable}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+                      (_: {
+                        services.proxmox-ve.enable = true;
+                        isoImage.isoBaseName = "nixos-proxmox-ve";
+                      })
+                    ];
+                  }).config.system.build.isoImage;
+              };
 
             checks =
               if (system == "x86_64-linux") then

--- a/flake.nix
+++ b/flake.nix
@@ -42,11 +42,14 @@
           in
           {
             overlays =
-              _: prev:
-              (import ./pkgs {
+              final: prev:
+              {
+                inherit lib;
+                unstable = unstable.legacyPackages.${system};
+              }
+              // (import ./pkgs {
                 inherit craneLib;
-                pkgs = prev;
-                pkgs-stable = pkgs;
+                pkgs = final;
               })
               // {
                 nixos-proxmox-ve-iso =

--- a/modules/proxmox-ve/cluster.nix
+++ b/modules/proxmox-ve/cluster.nix
@@ -5,7 +5,11 @@
   ...
 }:
 
-lib.mkIf config.services.proxmox-ve.enable {
+let
+  cfg = config.services.proxmox-ve;
+in
+
+lib.mkIf cfg.enable {
   systemd.services = {
     pve-cluster = {
       description = "The Proxmox VE cluster filesystem";
@@ -29,7 +33,7 @@ lib.mkIf config.services.proxmox-ve.enable {
       #  Conflicts = [ "shutdown.target" ];
       #};
       serviceConfig = {
-        ExecStart = "${pkgs.pve-cluster}/bin/pmxcfs";
+        ExecStart = "${cfg.package}/bin/pmxcfs";
         KillMode = "mixed";
         Restart = "on-failure";
         TimeoutStopSec = 10;

--- a/modules/proxmox-ve/default.nix
+++ b/modules/proxmox-ve/default.nix
@@ -20,11 +20,16 @@ in
     ./cluster.nix
     # ./firewall.nix
     # ./ha-manager.nix
+    ./linstor.nix
     ./manager.nix
     ./rrdcached.nix
   ];
 
-  options.services.proxmox-ve.enable = mkEnableOption (mdDoc ''Proxmox VE'');
+  options.services.proxmox-ve = {
+    enable = mkEnableOption "Proxmox VE";
+
+    package = mkPackageOption pkgs "proxmox-ve" { };
+  };
 
   config = mkIf cfg.enable (mkMerge [
     {

--- a/modules/proxmox-ve/default.nix
+++ b/modules/proxmox-ve/default.nix
@@ -71,7 +71,7 @@ in
       };
       users.groups.www-data = { };
 
-      environment.systemPackages = [ pkgs.proxmox-ve ];
+      environment.systemPackages = [ cfg.package ];
       environment.etc.issue.enable = false;
 
       networking.firewall.allowedTCPPorts = [

--- a/modules/proxmox-ve/linstor.nix
+++ b/modules/proxmox-ve/linstor.nix
@@ -31,15 +31,29 @@ in
         after = [ "network-online.target" ];
         before = [ "pvedaemon.service" ];
         serviceConfig = {
-          ExecStart = "${pkgs.linstor-server}/bin/linstor-controller";
           Type = "notify";
-          PrivateTmp = true;
-          SuccessExitStatus = "0 143 129";
+          ExecStart = "${pkgs.linstor-server}/bin/linstor-controller";
           Restart = "on-failure";
+          # if killed by signal 143 -> SIGTERM, 129 -> SIGHUP
+          SuccessExitStatus = "0 143 129";
+          PrivateTmp = true;
         };
       };
 
-    };
+      linstor-satellite = {
+        description = "LINSTOR Satellite Service";
+        wantedBy = [ "multi-user.target" ];
+        wants = [ "network-online.target" ];
+        after = [ "network-online.target" ];
+        before = [ "pvedaemon.service" ];
 
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${pkgs.linstor-server}/bin/linstor-satellite --logs=/var/log/linstor-satellite --config-directory=/etc/linstor";
+          SuccessExitStatus = "0 143 129";
+          PrivateTmp = true;
+        };
+      };
+    };
   };
 }

--- a/modules/proxmox-ve/linstor.nix
+++ b/modules/proxmox-ve/linstor.nix
@@ -19,8 +19,6 @@ in
   options.services.proxmox-ve.linstor.enable = mkEnableOption "Linstor for Proxmox VE";
 
   config = mkIf cfg.enable {
-    boot.kernelModules = [ "drbd" ];
-
     services.proxmox-ve.package = pkgs.proxmox-ve.override { enableLinstor = true; };
 
     systemd.services = {

--- a/modules/proxmox-ve/linstor.nix
+++ b/modules/proxmox-ve/linstor.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+let
+  cfg = config.services.proxmox-ve.linstor;
+in
+
+{
+  meta.maintainers = with maintainers; [
+    julienmalka
+    camillemndn
+  ];
+
+  options.services.proxmox-ve.linstor.enable = mkEnableOption "Linstor for Proxmox VE";
+
+  config = mkIf cfg.enable {
+    services.proxmox-ve.package = pkgs.proxmox-ve.override { enableLinstor = true; };
+  };
+}

--- a/modules/proxmox-ve/linstor.nix
+++ b/modules/proxmox-ve/linstor.nix
@@ -23,6 +23,10 @@ in
 
   config = mkIf cfg.enable {
     boot.extraModulePackages = with config.boot.kernelPackages; [ drbd ];
+    boot.kernelModules = [
+      "dm_thin_pool"
+      "drbd"
+    ];
 
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [
       3366

--- a/modules/proxmox-ve/linstor.nix
+++ b/modules/proxmox-ve/linstor.nix
@@ -19,6 +19,8 @@ in
   options.services.proxmox-ve.linstor.enable = mkEnableOption "Linstor for Proxmox VE";
 
   config = mkIf cfg.enable {
+    boot.kernelModules = [ "drbd" ];
+
     services.proxmox-ve.package = pkgs.proxmox-ve.override { enableLinstor = true; };
 
     systemd.services = {

--- a/modules/proxmox-ve/linstor.nix
+++ b/modules/proxmox-ve/linstor.nix
@@ -20,5 +20,24 @@ in
 
   config = mkIf cfg.enable {
     services.proxmox-ve.package = pkgs.proxmox-ve.override { enableLinstor = true; };
+
+    systemd.services = {
+      linstor-controller = {
+        description = "Linstor Controller";
+        wantedBy = [ "multi-user.target" ];
+        wants = [ "network-online.target" ];
+        after = [ "network-online.target" ];
+        before = [ "pvedaemon.service" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.linstor-server}/bin/linstor-controller";
+          Type = "notify";
+          PrivateTmp = true;
+          SuccessExitStatus = "0 143 129";
+          Restart = "on-failure";
+        };
+      };
+
+    };
+
   };
 }

--- a/modules/proxmox-ve/linstor.nix
+++ b/modules/proxmox-ve/linstor.nix
@@ -28,6 +28,25 @@ in
       "drbd"
     ];
 
+    services.drbd = {
+      enable = true;
+      config = ''
+            global {
+        	usage-count yes;
+
+        	# Decide what kind of udev symlinks you want for "implicit" volumes
+        	# (those without explicit volume <vnr> {} block, implied vnr=0):
+        	# /dev/drbd/by-resource/<resource>/<vnr>   (explicit volumes)
+        	# /dev/drbd/by-resource/<resource>         (default for implict)
+        	udev-always-use-vnr; # treat implicit the same as explicit volumes
+
+        	# minor-count dialog-refresh disable-ip-verification
+        	# cmd-timeout-short 5; cmd-timeout-medium 121; cmd-timeout-long 600;
+        }
+        include "/var/lib/linstor.d/*.res";
+      '';
+    };
+
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [
       3366
       3367

--- a/modules/proxmox-ve/linstor.nix
+++ b/modules/proxmox-ve/linstor.nix
@@ -16,10 +16,18 @@ in
     camillemndn
   ];
 
-  options.services.proxmox-ve.linstor.enable = mkEnableOption "Linstor for Proxmox VE";
+  options.services.proxmox-ve.linstor = {
+    enable = mkEnableOption "Linstor for Proxmox VE";
+    openFirewall = mkEnableOption "opening the default ports in the firewall for Linstor Satellite";
+  };
 
   config = mkIf cfg.enable {
     boot.extraModulePackages = with config.boot.kernelPackages; [ drbd ];
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [
+      3366
+      3367
+    ];
 
     services.proxmox-ve.package = pkgs.proxmox-ve.override { enableLinstor = true; };
 

--- a/modules/proxmox-ve/linstor.nix
+++ b/modules/proxmox-ve/linstor.nix
@@ -19,6 +19,8 @@ in
   options.services.proxmox-ve.linstor.enable = mkEnableOption "Linstor for Proxmox VE";
 
   config = mkIf cfg.enable {
+    boot.extraModulePackages = with config.boot.kernelPackages; [ drbd ];
+
     services.proxmox-ve.package = pkgs.proxmox-ve.override { enableLinstor = true; };
 
     systemd.services = {

--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -28,6 +28,7 @@ lib.mkIf cfg.enable {
         PIDFile = "/run/pvedaemon.pid";
         Type = "forking";
         Restart = "on-failure";
+        CacheDirectory = "linstor-proxmox";
       };
     };
 

--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -5,7 +5,11 @@
   ...
 }:
 
-lib.mkIf config.services.proxmox-ve.enable {
+let
+  cfg = config.services.proxmox-ve;
+in
+
+lib.mkIf cfg.enable {
   systemd.services = {
     pvedaemon = {
       description = "PVE API Daemon";
@@ -18,9 +22,9 @@ lib.mkIf config.services.proxmox-ve.enable {
         "pve-cluster.service"
       ];
       serviceConfig = {
-        ExecStart = "${pkgs.pve-manager}/bin/pvedaemon start";
-        ExecStop = "${pkgs.pve-manager}/bin/pvedaemon stop";
-        ExecReload = "${pkgs.pve-manager}/bin/pvedaemon restart";
+        ExecStart = "${cfg.package}/bin/pvedaemon start";
+        ExecStop = "${cfg.package}/bin/pvedaemon stop";
+        ExecReload = "${cfg.package}/bin/pvedaemon restart";
         PIDFile = "/run/pvedaemon.pid";
         Type = "forking";
         Restart = "on-failure";
@@ -43,13 +47,13 @@ lib.mkIf config.services.proxmox-ve.enable {
       ];
       serviceConfig = {
         ExecStartPre = [
-          "${pkgs.pve-cluster}/bin/pvecm updatecerts -silent"
+          "${cfg.package}/bin/pvecm updatecerts -silent"
           "${pkgs.coreutils}/bin/touch /var/lock/pveproxy.lck"
           "${pkgs.coreutils}/bin/chown -R www-data:www-data /var/lock/pveproxy.lck"
         ];
-        ExecStart = "${pkgs.pve-manager}/bin/pveproxy start";
-        ExecStop = "${pkgs.pve-manager}/bin/pveproxy stop";
-        ExecReload = "${pkgs.pve-manager}/bin/pveproxy restart";
+        ExecStart = "${cfg.package}/bin/pveproxy start";
+        ExecStop = "${cfg.package}/bin/pveproxy stop";
+        ExecReload = "${cfg.package}/bin/pveproxy restart";
         PIDFile = "/run/pveproxy/pveproxy.pid";
         Type = "forking";
         StateDirectory = "pve-manager";
@@ -82,11 +86,11 @@ lib.mkIf config.services.proxmox-ve.enable {
         RefuseManualStop = true;
       };
       serviceConfig = {
-        #ExecStartPre = "${pkgs.pve-manager}/share/pve-manager/helpers/pve-startall-delay";
-        ExecStart = "${pkgs.pve-manager}/bin/pvesh --nooutput create /nodes/localhost/startall";
+        #ExecStartPre = "${cfg.package}/share/pve-manager/helpers/pve-startall-delay";
+        ExecStart = "${cfg.package}/bin/pvesh --nooutput create /nodes/localhost/startall";
         ExecStop = pkgs.writeShellScript "pve-guests-stop" ''
-          -${pkgs.pve-manager}/bin/vzdump -stop
-          ${pkgs.pve-manager}/bin/pvesh --nooutput create /nodes/localhost/stopall
+          -${cfg.package}/bin/vzdump -stop
+          ${cfg.package}/bin/pvesh --nooutput create /nodes/localhost/stopall
         '';
         Type = "oneshot";
         RemainAfterExit = true;
@@ -103,7 +107,7 @@ lib.mkIf config.services.proxmox-ve.enable {
         Before = [ "console-getty.service" ];
       };
       serviceConfig = {
-        ExecStart = "${pkgs.pve-manager}/bin/pvebanner";
+        ExecStart = "${cfg.package}/bin/pvebanner";
         Type = "oneshot";
         RemainAfterExit = true;
       };
@@ -123,9 +127,9 @@ lib.mkIf config.services.proxmox-ve.enable {
           "${pkgs.coreutils}/bin/touch /var/lib/pve-manager/pve-replication-state.lck"
           "${pkgs.coreutils}/bin/chown -R www-data:www-data /var/lib/pve-manager/pve-replication-state.lck"
         ];
-        ExecStart = "${pkgs.pve-manager}/bin/pvescheduler start";
-        ExecStop = "${pkgs.pve-manager}/bin/pvescheduler stop";
-        ExecReload = "${pkgs.pve-manager}/bin/pvescheduler restart";
+        ExecStart = "${cfg.package}/bin/pvescheduler start";
+        ExecStop = "${cfg.package}/bin/pvescheduler stop";
+        ExecReload = "${cfg.package}/bin/pvescheduler restart";
         PIDFile = "/var/run/pvescheduler.pid";
         KillMode = "process";
         Type = "forking";
@@ -137,9 +141,9 @@ lib.mkIf config.services.proxmox-ve.enable {
       wants = [ "pve-cluster.service" ];
       after = [ "pve-cluster.service" ];
       serviceConfig = {
-        ExecStart = "${pkgs.pve-manager}/bin/pvestatd start";
-        ExecStop = "${pkgs.pve-manager}/bin/pvestatd stop";
-        ExecReload = "${pkgs.pve-manager}/bin/pvestatd restart";
+        ExecStart = "${cfg.package}/bin/pvestatd start";
+        ExecStop = "${cfg.package}/bin/pvestatd stop";
+        ExecReload = "${cfg.package}/bin/pvestatd restart";
         PIDFile = "/run/pvestatd.pid";
         Type = "forking";
       };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -59,6 +59,8 @@ let
     pve-storage = callPackage ./pve-storage { };
     pve-xtermjs = callPackage ./pve-xtermjs { };
 
+    linstor-api-py = callPackage ./linstor-api-py { };
+    linstor-client = callPackage ./linstor-client { };
     linstor-proxmox = callPackage ./linstor-proxmox { };
   };
 in

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,15 +1,12 @@
 {
   pkgs,
-  pkgs-stable ? pkgs,
+  pkgs-unstable,
   craneLib ? { },
   ...
 }:
 let
-  callPackage = pkgs.lib.callPackageWith (pkgs // ours // {
-    # Any package that is used for override should be listed here to make this flake
-    # work on anything other than nixos release.
-    inherit (pkgs-stable) qemu novnc;
-  });
+  callPackage = pkgs.lib.callPackageWith (pkgs // ours);
+
   ours = {
     inherit craneLib;
 
@@ -62,8 +59,8 @@ let
     linstor-api-py = callPackage ./linstor-api-py { };
     linstor-client = callPackage ./linstor-client { };
     linstor-proxmox = callPackage ./linstor-proxmox { };
-    linstor-server = pkgs.unstable.callPackage ./linstor-server {
-      protobuf = pkgs.unstable.protobuf_23;
+    linstor-server = pkgs-unstable.callPackage ./linstor-server {
+      protobuf = pkgs-unstable.protobuf_23;
       jre = pkgs.jdk11_headless;
     };
   };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -62,6 +62,10 @@ let
     linstor-api-py = callPackage ./linstor-api-py { };
     linstor-client = callPackage ./linstor-client { };
     linstor-proxmox = callPackage ./linstor-proxmox { };
+    linstor-server = pkgs.unstable.callPackage ./linstor-server {
+      protobuf = pkgs.unstable.protobuf_23;
+      jre = pkgs.jdk11_headless;
+    };
   };
 in
 ours

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -58,6 +58,8 @@ let
     pve-rs = callPackage ./pve-rs { };
     pve-storage = callPackage ./pve-storage { };
     pve-xtermjs = callPackage ./pve-xtermjs { };
+
+    linstor-proxmox = callPackage ./linstor-proxmox { };
   };
 in
 ours

--- a/pkgs/linstor-api-py/default.nix
+++ b/pkgs/linstor-api-py/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "linstor-api-py";
+  version = "1.23.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LINBIT";
+    repo = "linstor-api-py";
+    rev = "v${version}";
+    hash = "sha256-+nv1Lp14X7a5BVHYGWFEESO95MsTa6NLPJSRJvIJc3w=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  pythonImportsCheck = [ "linstor" ];
+
+  meta = with lib; {
+    description = "LINSTOR Python API";
+    homepage = "https://github.com/LINBIT/linstor-api-py";
+    changelog = "https://github.com/LINBIT/linstor-api-py/blob/${src.rev}/CHANGELOG.md";
+    license = [ ];
+    maintainers = with maintainers; [
+      camillemndn
+      julienmalka
+    ];
+  };
+}

--- a/pkgs/linstor-client/default.nix
+++ b/pkgs/linstor-client/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  linstor-api-py,
+  nix-update-script,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "linstor-client";
+  version = "1.23.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LINBIT";
+    repo = "linstor-client";
+    rev = "v${version}";
+    hash = "sha256-DxYtqJr8ZOlwQdX4s4UF1BnzQsJQaYQOYOupbN3kD5k=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = [ linstor-api-py ];
+
+  pythonImportsCheck = [ "linstor_client" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--flake" ]; };
+
+  meta = with lib; {
+    description = "Python client for LINSTOR";
+    homepage = "https://github.com/LINBIT/linstor-client";
+    changelog = "https://github.com/LINBIT/linstor-client/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [
+      camillemndn
+      julienmalka
+    ];
+    mainProgram = "linstor-client";
+  };
+}

--- a/pkgs/linstor-client/default.nix
+++ b/pkgs/linstor-client/default.nix
@@ -38,6 +38,6 @@ python3.pkgs.buildPythonApplication rec {
       camillemndn
       julienmalka
     ];
-    mainProgram = "linstor-client";
+    mainProgram = "linstor";
   };
 }

--- a/pkgs/linstor-proxmox/default.nix
+++ b/pkgs/linstor-proxmox/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   perl536,
-  pve-storage,
   nix-update-script,
 }:
 
@@ -12,7 +11,6 @@ let
     JSONXS
     RESTClient
     TypesSerialiser
-    pve-storage
   ];
 
   perlEnv = perl536.withPackages (_: perlDeps);

--- a/pkgs/linstor-proxmox/default.nix
+++ b/pkgs/linstor-proxmox/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  perl536,
+  pve-storage,
+  nix-update-script,
+}:
+
+let
+  perlDeps = with perl536.pkgs; [
+    JSONXS
+    RESTClient
+    TypesSerialiser
+    pve-storage
+  ];
+
+  perlEnv = perl536.withPackages (_: perlDeps);
+in
+
+perl536.pkgs.toPerlModule (
+  stdenv.mkDerivation rec {
+    pname = "linstor-proxmox";
+    version = "8.0.4";
+
+    src = fetchFromGitHub {
+      owner = "LINBIT";
+      repo = "linstor-proxmox";
+      rev = "v${version}";
+      hash = "sha256-aQ9VqQcF9jDGcv2anKPunTTNyS1exJcODt7WkcGxH+o=";
+    };
+
+    makeFlags = [
+      "DESTDIR=$(out)"
+      "PERLDIR=/${perl536.libPrefix}/${perl536.version}"
+    ];
+
+    buildInputs = [ perlEnv ];
+
+    passthru.updateScript = nix-update-script { extraArgs = [ "--flake" ]; };
+
+    meta = with lib; {
+      description = "Integration pluging bridging LINSTOR to Proxmox VE";
+      homepage = "https://github.com/LINBIT/linstor-proxmox";
+      changelog = "https://github.com/LINBIT/linstor-proxmox/blob/${src.rev}/CHANGELOG.md";
+      license = [ ];
+      maintainers = with maintainers; [
+        camillemndn
+        julienmalka
+      ];
+      platforms = platforms.linux;
+    };
+  }
+)

--- a/pkgs/linstor-proxmox/default.nix
+++ b/pkgs/linstor-proxmox/default.nix
@@ -36,6 +36,7 @@ perl536.pkgs.toPerlModule (
     ];
 
     buildInputs = [ perlEnv ];
+    propagatedBuildInputs = perlDeps;
 
     passthru.updateScript = nix-update-script { extraArgs = [ "--flake" ]; };
 
@@ -43,7 +44,7 @@ perl536.pkgs.toPerlModule (
       description = "Integration pluging bridging LINSTOR to Proxmox VE";
       homepage = "https://github.com/LINBIT/linstor-proxmox";
       changelog = "https://github.com/LINBIT/linstor-proxmox/blob/${src.rev}/CHANGELOG.md";
-      license = [ ];
+      license = licenses.agpl3Plus;
       maintainers = with maintainers; [
         camillemndn
         julienmalka

--- a/pkgs/linstor-server/build.patch
+++ b/pkgs/linstor-server/build.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile b/Makefile
+index 0646cedd7..6d932bae3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -16,7 +16,7 @@ GENSRC=./server/generated-src
+ VERSINFO=$(GENRES)/version-info.properties
+ 
+ # echo v0.1 to get it started
+-VERSION ?= $(shell echo $(shell git describe --tags || echo "v0.1") | sed -e 's/^v//;s/^[^0-9]*//;s/\(.*\)-g/\1-/')
++VERSION ?= $(shell echo $(shell git describe --tags ) | sed -e 's/^v//;s/^[^0-9]*//;s/\(.*\)-g/\1-/')
+ GITHASH := $(shell git rev-parse HEAD)
+ DEBVERSION = $(shell echo $(VERSION) | sed -e 's/-/~/g')
+ 
+diff --git a/build.gradle b/build.gradle
+index 846bc752b..053a33c46 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -173,13 +173,8 @@ project(':server') {
+      * tarball, and it is then skipped when the package is finally built.
+      */
+     tasks.register('generateProto', Exec) {
+-        doFirst {
+-            if (!protoc.exists()) {
+-                throw new GradleException("'protoc' binary not found; run the task 'getProtoc' to download the binary")
+-            }
+-        }
+ 
+-        commandLine 'make', '-C', "${projectDir}/proto", "PROTOC=" + protoc, 'proto'
++        commandLine 'make', '-C', "${projectDir}/proto", "PROTOC=protoc", 'proto'
+ 
+         inputs.files(fileTree("${projectDir}/proto"))
+         outputs.dir(file("${projectDir}/generated-src"))

--- a/pkgs/linstor-server/default.nix
+++ b/pkgs/linstor-server/default.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gradle,
+  protobuf,
+  git,
+  python3,
+  makeWrapper,
+  jre,
+  bashInteractive,
+  bcache-tools,
+  coreutils,
+  cryptsetup,
+  drbd,
+  gnugrep,
+  kmod,
+  lsscsi,
+  lvm2,
+  mount,
+  nvme-cli,
+  systemdMinimal,
+  thin-provisioning-tools,
+  util-linux,
+  zfs,
+}:
+
+let
+  self = stdenv.mkDerivation (finalAttrs: {
+    pname = "linstor-server";
+    version = "1.29.0";
+
+    src = fetchFromGitHub {
+      owner = "LINBIT";
+      repo = "linstor-server";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-Dy+3kzfw3y1LhYa7+sGv4YmNeP4ao4NfXUA2dFgzsJE=";
+      fetchSubmodules = true;
+      leaveDotGit = true;
+    };
+
+    patches = [ ./build.patch ];
+    postPatch = ''
+      find . -type f -name "*.java" -exec sed -i {} -e "s|/bin/bash|${bashInteractive}/bin/bash|g" \;
+    '';
+
+    nativeBuildInputs = [
+      gradle
+      protobuf
+      git
+      python3
+      makeWrapper
+    ];
+
+    buildInputs = [ protobuf ];
+
+    gradleBuildTask = "installDist";
+
+    preBuild = ''
+      VERSION="${finalAttrs.version}" make versioninfo
+    '';
+
+    mitmCache = gradle.fetchDeps {
+      pkg = self;
+      data = ./deps.json;
+    };
+
+    gradleFlags = [ "-Dfile.encoding=utf-8" ];
+
+    doCheck = false;
+
+    installPhase = ''
+      mkdir -p $out/bin
+      mkdir -p $out/lib/conf
+      cp -r build/install/linstor-server/lib/* $out/lib/
+      cp server/logback.xml $out/lib/conf/
+      makeWrapper ${jre}/bin/java $out/bin/linstor-controller \
+        --add-flags "-Xms32M -classpath $out/lib/conf:$out/lib/* com.linbit.linstor.core.Controller" \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            bcache-tools
+            coreutils
+            cryptsetup
+            drbd
+            gnugrep
+            kmod
+            lsscsi
+            lvm2
+            mount
+            nvme-cli
+            systemdMinimal
+            thin-provisioning-tools
+            util-linux
+            zfs
+          ]
+        }
+
+      makeWrapper ${jre}/bin/java $out/bin/linstor-satellite \
+        --add-flags "-Xms32M -classpath $out/lib/conf:$out/lib/* com.linbit.linstor.core.Satellite" \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            bcache-tools
+            coreutils
+            cryptsetup
+            drbd
+            gnugrep
+            kmod
+            lsscsi
+            lvm2
+            mount
+            nvme-cli
+            systemdMinimal
+            thin-provisioning-tools
+            util-linux
+            zfs
+          ]
+        }
+    '';
+  });
+
+in
+self

--- a/pkgs/linstor-server/deps.json
+++ b/pkgs/linstor-server/deps.json
@@ -1,0 +1,1223 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://repo.maven.apache.org/maven2": {
+  "aopalliance#aopalliance/1.0": {
+   "jar": "sha256-Ct3sZw/tzT8RPFyAkdeDKA0j9146y4QbYanNsHk3agg=",
+   "pom": "sha256-JugjMBV9a4RLZ6gGSUXiBlgedyl3GD4+Mf7GBYqppZs="
+  },
+  "ch/qos/logback#logback-classic/1.3.8": {
+   "jar": "sha256-snR0eMVmR6fzh3kUxUpXgu5ucrwSVEP3l89TbKIoyWg=",
+   "pom": "sha256-BvKm4x+RFrKLDD5MjFh714Zm4miYahDdbeso1N9anyA="
+  },
+  "ch/qos/logback#logback-core/1.3.8": {
+   "jar": "sha256-8LejE0Os5ub5UKbmRPHkja+dnY9cM1dwiGDwBaOrzi4=",
+   "pom": "sha256-8Io434MBF/bK3t/gncjsda1YNBLpcKTjFxbxPqEOzes="
+  },
+  "ch/qos/logback#logback-parent/1.3.8": {
+   "pom": "sha256-UP4vDMsqb7uAaaihDHge6IJMicVvU8XjJL+h3UXffno="
+  },
+  "com/amazonaws#aws-java-sdk-bom/1.12.496": {
+   "pom": "sha256-01KXUg2iz6SU76oD5mbi+KDh2Y9u321kdWsaKOALqDk="
+  },
+  "com/amazonaws#aws-java-sdk-core/1.12.496": {
+   "jar": "sha256-J50g+HEqUEVWptMLJSv1SGgpKVhR26y7l84LXsJT/g8=",
+   "pom": "sha256-nd+WNP31oggK8xl9olj7yoSTmvyg46tcXEUunHa9+GM="
+  },
+  "com/amazonaws#aws-java-sdk-ebs/1.12.496": {
+   "jar": "sha256-tQG7oPw7Lf+QIvL26rngaLFYXHsm2wG3uQA7V27METg=",
+   "pom": "sha256-MRzDa8scxY/0JYhE0Zkt/NDN95YgXAJpOgbJWZkur1Y="
+  },
+  "com/amazonaws#aws-java-sdk-ec2/1.12.496": {
+   "jar": "sha256-uuCAWQpc+MHzt3qlx6S+7oAvN7kvlUYqKkVqFcBmE0w=",
+   "pom": "sha256-x+KnUSDoWP2gPh4jHuInOm/t9EEAjOEXJ05sYtuPn4Y="
+  },
+  "com/amazonaws#aws-java-sdk-kms/1.12.496": {
+   "jar": "sha256-zGdTbrxduuX+aN8nn17jBR1gY4q9vgGjs53xrUMRfiE=",
+   "pom": "sha256-Y3GuT3G6YcPTZQ34QkbO7xCU3MpZqXfDAkW9XmDC/ng="
+  },
+  "com/amazonaws#aws-java-sdk-pom/1.12.496": {
+   "pom": "sha256-Juyfei09PGiswsaIX+4aSKooGnylXK8DZjb2hkSwg7Q="
+  },
+  "com/amazonaws#aws-java-sdk-s3/1.12.496": {
+   "jar": "sha256-g1WmsUH8KrjZD3u5xaB1w3ZZtzYFhXClL/d6iB9FFE8=",
+   "pom": "sha256-tTpd0WaRmQEvsGwRTu9umEsOGkNDECkj8WBW4ipMUoE="
+  },
+  "com/amazonaws#jmespath-java/1.12.496": {
+   "jar": "sha256-I5WlDQ0xaoQP0+JcpXMH41k6KsMJAvDZr0hKPwzJAPk=",
+   "pom": "sha256-Os4RXJ42IDxR9nPx+siyQHqppOcUvsF7PobywU5F0I8="
+  },
+  "com/cronutils#cron-utils/9.1.6": {
+   "jar": "sha256-I2xgYJP9geaSdKX8i1b2tb6P3yLRbd9oQQmEhu9s8Sw=",
+   "pom": "sha256-eyaQ5ZLfYUp+vMV9TqNsSh2ivzzTEnGPanlSgHmaVHg="
+  },
+  "com/fasterxml#oss-parent/38": {
+   "pom": "sha256-yD+PRd/cqNC2s2YcYLP4R4D2cbEuBvka1dHBodH5Zug="
+  },
+  "com/fasterxml#oss-parent/41": {
+   "pom": "sha256-r2UPpN1AC8V2kyC87wjtk4E/NJyr6CE9RprK+72UXYo="
+  },
+  "com/fasterxml#oss-parent/50": {
+   "pom": "sha256-9dpV3XuI+xcMRoAdF3dKZS+y9FgftbHQpfyGqhgrhXc="
+  },
+  "com/fasterxml/jackson#jackson-base/2.11.4": {
+   "pom": "sha256-F0xU8G6vYz4PIW5s/Mf9zcgaIHmAFNh/KfI54rdgqg0="
+  },
+  "com/fasterxml/jackson#jackson-base/2.12.6": {
+   "pom": "sha256-cZmfWXUi5fUOtBR07iy+K5mRZRki7ooJDgC4dC3oyaY="
+  },
+  "com/fasterxml/jackson#jackson-base/2.15.2": {
+   "pom": "sha256-gR/6GyOZVv1RJTfuvYgQ1VyolIEV6utr7RN0OVsWEYI="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.11.4": {
+   "pom": "sha256-DbN+ozP5eemavw1/bh5w3ztnWu6+CnK+WQXo6R00aaI="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.12.6": {
+   "pom": "sha256-E2EHjtiug+qn6GDRZDiSSf83Qszf7yXKMySN/WLlU0I="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.15.2": {
+   "pom": "sha256-Hq1jAlXEiMUbXgq1YMdsI3GtJq422t8JKcUmVy6ls4s="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.11": {
+   "pom": "sha256-wbChPYz+Y7QLD66EWLmUYxae0MYPf8lj7z8FJXFQy+g="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.12": {
+   "pom": "sha256-YqocFnmt4J8XPb8bbDLTXFXnWAAjj9XkjxOqQzfAh1s="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.15": {
+   "pom": "sha256-bN+XvGbzifY+NoUNL1UtEhZoj45aWHJ9P2qY7fhnXN4="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.11.4": {
+   "pom": "sha256-b+hdYiduDCsHiyhDkYY6uYN+2O44RyVkaa5ewG6MUoo="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.15.2": {
+   "jar": "sha256-BOIflNz+5LB4+lpfUwR7eFqrpp0Z3jkvYW56f+XTiC8=",
+   "module": "sha256-J9oBZ5NhzrL7aM7U2QUsbwZtKCMECzlhauJFsml1Lxg=",
+   "pom": "sha256-zffBunjNIWJW1JyP/T/9tCR5/HH4gsLdWFiwnqMx22Q="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.11.4": {
+   "pom": "sha256-yv/tFG5mfec0TCEP6O2gJBvBh/xWBiN+GDVxHQxWZ94="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.15.2": {
+   "jar": "sha256-MDyZ6CsfqpGguuXY++tW9+Kt+bUmqQDdcjvxQNYr1LQ=",
+   "module": "sha256-kkYXeTlf4sRJWfjVNM6P1qVv9OcTaEQ3VnxtOBCO1ik=",
+   "pom": "sha256-kePK1TxteeWBzNjZgLpfmc56IV9HzjyFaZeiUeGT7GE="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.11.4": {
+   "pom": "sha256-XMXGVv1f5WqaFhQyPPDz7cc3GDkrjR2OzyeYBFtTu8c="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.15.2": {
+   "jar": "sha256-DrL9rW5Aq4gyp4ybIvWBlt2XBZTo09Wibq2HhHxPOpY=",
+   "module": "sha256-8ssss51IhZ/13mWVeUikMfsa5vXVOOYsqJPD1LviC1Q=",
+   "pom": "sha256-mGNZbYwF1eKd6DrIRYayTIlvm6BlRLjyPG3eZOftbpw="
+  },
+  "com/fasterxml/jackson/core/jackson-databind/maven-metadata": {
+   "xml": {
+    "groupId": "com.fasterxml.jackson.core",
+    "lastUpdated": "20240705171737",
+    "release": "2.17.2"
+   }
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-cbor/2.12.6": {
+   "module": "sha256-SpqXn3cK9t1UvLPABXJAFXERtfp+L7J99tfYBWBW0Go=",
+   "pom": "sha256-ha9YnMuV1fQ1t/O5iVv07lyi6ZXfsyq/R2encs0cmrI="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-cbor/2.15.2": {
+   "jar": "sha256-V7qJpD5jG+LeZ67thGplmxXGuCt7JUFk9hvzCQzMKtE=",
+   "module": "sha256-Xt6HUJ/Uro3yxXpkYgMxB8i5WwfiS9HOyVwe39OPTks=",
+   "pom": "sha256-5hiKTjhDnorFy2/8r4pd86OGRZgdulqqUHn1ZNh/rIE="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.15.2": {
+   "jar": "sha256-N3lcwejLlLGNhg3Dq9Llk2F85AIUmuRaqJ7Yv7iByFE=",
+   "module": "sha256-Zhi6Ju7z6r0YjuUaU5Ud0ozArk26H8ZFCm4ut1r+gHI=",
+   "pom": "sha256-FtirhVBQo9DU4DS5Oe3Uqy2uPOx4fsv377FFVTc0Cj4="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-binary/2.12.6": {
+   "pom": "sha256-uAAxuMuWG3O1yzWnxyD19gRMLsUn/fw0HnE8/KGZfAg="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-binary/2.15.2": {
+   "pom": "sha256-farElfvdVx1C2SBAi0Bs1AbvJN/kpYNK3A9v+/HYxsI="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.15.2": {
+   "pom": "sha256-APj0+4RCvYUMoepR3XYc90vyx1eb6YyntIUYuVbkmjY="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatype-jsr310/2.15.2": {
+   "jar": "sha256-dXTIGtVwR272qtJvQZKI/UZnM/MxW+4wEvLynJ3ACMg=",
+   "module": "sha256-dC7PdkWs0Yq7nZZxDD0hIsLYYmia2kgB4gi3RI/1i48=",
+   "pom": "sha256-2wyWlWrnBmn/2YS0rcBcknu4Zkv3MrhgLg1mzEtt/1c="
+  },
+  "com/fasterxml/jackson/jr#jackson-jr-objects/2.11.4": {
+   "pom": "sha256-UcM0oxlVeZZQ+rPijPngGo6Hjjsa/amTdicmhx2G8e0="
+  },
+  "com/fasterxml/jackson/jr#jackson-jr-objects/2.15.2": {
+   "jar": "sha256-lGi2HcxljrkCpA4UkqbAwk5vzXuswKSC7xOgB7IkxSI=",
+   "module": "sha256-duWhI15DdvTj5mE5uch8AmQFFjexzXFor4RFlcx6eUg=",
+   "pom": "sha256-Zxg26YtOF0odgkafRcXCPNlJ+HmMsbbE+mKLl2pjGz8="
+  },
+  "com/fasterxml/jackson/jr#jackson-jr-parent/2.11.4": {
+   "pom": "sha256-bim4s2ny2SCYXbzczFNTlD08a0mSXyvuZhU9/n8Ms3k="
+  },
+  "com/fasterxml/jackson/jr#jackson-jr-parent/2.15.2": {
+   "pom": "sha256-ACUf0m6OtxiFuh/NST5D1Kj+mzt/rYDW82xIVjV+4Iw="
+  },
+  "com/fasterxml/jackson/jr/jackson-jr-objects/maven-metadata": {
+   "xml": {
+    "groupId": "com.fasterxml.jackson.jr",
+    "lastUpdated": "20240705171946",
+    "release": "2.17.2"
+   }
+  },
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.15.2": {
+   "pom": "sha256-ySmc8tVgUfC2f+PPsl95GF5xcTyAkON/4xjA3TpTgI8="
+  },
+  "com/github/ben-manes/caffeine#caffeine/2.9.3": {
+   "jar": "sha256-Hgp7vvHdeRZTFD8/BdDkiZNL9UgeWKh8nmGc1Gtocps=",
+   "module": "sha256-J9/TStZlaZDTxzF2NEsJkfLIJwn6swcJs93qj6MAMHA=",
+   "pom": "sha256-b6TxwQGSgG+O8FtdS+e9n1zli4dvZDZNTpDD/AkjI9w="
+  },
+  "com/github/waffle#waffle-jna/3.2.0": {
+   "jar": "sha256-X847y0w1xO4DTlcNCeO7QMx0eTQE7XkjFBn6C42Cy7I=",
+   "pom": "sha256-P3HqT1PVIEHW8tgUpRzJEfJLncTmFF3HsNg6FEq3Y1w="
+  },
+  "com/github/waffle#waffle-parent/3.2.0": {
+   "pom": "sha256-zijoPGvPHJ0wH6KdRqmoiZUL3km+MXDdaLGsKiinvHQ="
+  },
+  "com/google#google/5": {
+   "pom": "sha256-4J00XnPKP7yn8+BfMN63Tp053Wt5qT/ujFEfI0F7aCg="
+  },
+  "com/google/android#annotations/4.1.1.4": {
+   "jar": "sha256-unNOHoTAnWFa9qCdMwNLTwRC+Hct7BIO+zdthqVlrhU=",
+   "pom": "sha256-5LtUdTw2onoOXXAVSlA0/t2P6sQoIpUDS/1IPWx6rng="
+  },
+  "com/google/api/grpc#proto-google-common-protos/2.9.0": {
+   "jar": "sha256-DYMDgOxmvX4l7uY6oKWghXjkatGH+3LZm0TZuiKCf5E=",
+   "pom": "sha256-MflFokhqhZAOU4k3wZ7LWHE3mlQOBmwbMLFgSk7TX9s="
+  },
+  "com/google/auto#auto-parent/7": {
+   "pom": "sha256-pGQm/MtdMnBa2cu8mW94a9BIzIy90h2wRlABafFaQ1Y="
+  },
+  "com/google/auto/value#auto-value-annotations/1.6.3": {
+   "jar": "sha256-DpUf7owx9gJwvEZVOoWGABt7k9uxKuwGNzqpmhUDksA=",
+   "pom": "sha256-4fx4D37gJeZis9pycj2+KsjawKL4kg8mUxXE4b49dlw="
+  },
+  "com/google/auto/value#auto-value-parent/1.6.3": {
+   "pom": "sha256-5Z31cytMs01XJxgURvne2c5EJRMaChBiUZ7qGW3k2KE="
+  },
+  "com/google/code/findbugs#jsr305/3.0.1": {
+   "pom": "sha256-QXCnYdxb/TmBqOb3qrnirNzoLTT9Wqm7EePAkNJTFM4="
+  },
+  "com/google/code/findbugs#jsr305/3.0.2": {
+   "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
+   "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
+  },
+  "com/google/code/gson#gson-parent/2.8.1": {
+   "pom": "sha256-LSsaYLpxKFAyFpKsBsoRcRDrBV7FDyJMqWa6xZjx7hM="
+  },
+  "com/google/code/gson#gson-parent/2.8.5": {
+   "pom": "sha256-jx/scrkaceo57Dn193jE0RJLawl8bVWzpQtVSlIjeyc="
+  },
+  "com/google/code/gson#gson-parent/2.9.1": {
+   "pom": "sha256-fKCEXnNoVhjePka9NDTQOko3PVIPq5OmgDGK1sjLKnk="
+  },
+  "com/google/code/gson#gson/2.8.1": {
+   "pom": "sha256-yB7hCZh48NW4QrkIkEmanu1t29xPs/9Xt5LcLiinb9U="
+  },
+  "com/google/code/gson#gson/2.8.5": {
+   "pom": "sha256-uDCFV6f8zJLZ/nyM0FmSWLNhKF0uzedontqYhDJVoJI="
+  },
+  "com/google/code/gson#gson/2.9.1": {
+   "jar": "sha256-N4U04znm5tULFzb7Ort28cFdG+P0wTzsbVNkEuI9pgM=",
+   "pom": "sha256-5ZZjI9cUJXCzekvpeeIbwtroSBB+TcQW2PRNmqPwKQM="
+  },
+  "com/google/errorprone#error_prone_annotations/2.11.0": {
+   "pom": "sha256-AmHKAfLS6awq4uznXULFYyOzhfspS2vJQ/Yu9Okt3wg="
+  },
+  "com/google/errorprone#error_prone_annotations/2.14.0": {
+   "jar": "sha256-FJTiTnvVSW59b3BRad3dRggc77iC6k/GC0pYylB2fzQ=",
+   "pom": "sha256-nf/8jIg5kQhvQkuU44Pdd3yyflLpcJsujvReSA0wiG0="
+  },
+  "com/google/errorprone#error_prone_annotations/2.3.1": {
+   "pom": "sha256-PtzmtxG6No7+Frm3qssCFPvWSEFMublllTouftiagZo="
+  },
+  "com/google/errorprone#error_prone_annotations/2.7.1": {
+   "jar": "sha256-zVJXwIokbPhiiBeuccuCK+GS75H2iByko/z/Tx3hz/M=",
+   "pom": "sha256-Mahy4RScXzqLwF+03kVeXqYI7PrRryIst2N8psdi7iU="
+  },
+  "com/google/errorprone#error_prone_parent/2.11.0": {
+   "pom": "sha256-goPwy0TGJKedMwtv2AuLinFaaLNoXJqVHD3oN9RUBVE="
+  },
+  "com/google/errorprone#error_prone_parent/2.14.0": {
+   "pom": "sha256-OWyJX3pYRYPoQgvhZwkaIXUzpCbB7KUIrx0iqgOksrY="
+  },
+  "com/google/errorprone#error_prone_parent/2.3.1": {
+   "pom": "sha256-dnUl2agRKc0IGWg4KYAzYye+QWKx4iUaGCkR2qczwSM="
+  },
+  "com/google/errorprone#error_prone_parent/2.7.1": {
+   "pom": "sha256-Cm4kLigQToCTQFrjeWlmCkOLccTBtz/E/3FtuJ2ojeY="
+  },
+  "com/google/guava#failureaccess/1.0.1": {
+   "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
+   "pom": "sha256-6WBCznj+y6DaK+lkUilHyHtAopG1/TzWcqQ0kkEDxLk="
+  },
+  "com/google/guava#guava-parent/26.0-android": {
+   "pom": "sha256-+GmKtGypls6InBr8jKTyXrisawNNyJjUWDdCNgAWzAQ="
+  },
+  "com/google/guava#guava-parent/30.1-jre": {
+   "pom": "sha256-4q+3R+vE/iMo1qkPqIxdioO7HjIGG7mxD/Q+LEetbnM="
+  },
+  "com/google/guava#guava-parent/31.0.1-jre": {
+   "pom": "sha256-s7a2qnCZwRgXrO6FsyL9kffuMq6mn+CD7jbIc17AZ4g="
+  },
+  "com/google/guava#guava-parent/31.1-jre": {
+   "pom": "sha256-RDliZ4O0StJe8F/wdiHdS7eWzE608pZqSkYf6kEw4Pw="
+  },
+  "com/google/guava#guava/30.1-jre": {
+   "pom": "sha256-lkbUzVAJTUq+UH5VXT921340pMVWayL7Ew71XU676Sc="
+  },
+  "com/google/guava#guava/31.0.1-jre": {
+   "jar": "sha256-1b6U1l6HvSGfsxk60VF7qlWjuI/JHSHPc1gmq1rwh7k=",
+   "pom": "sha256-K+VmkgwhxgxcyvKCeGfK/3ZmRuIRO3/MPunCSkCy85Y="
+  },
+  "com/google/guava#guava/31.1-jre": {
+   "jar": "sha256-pC7cnKt5Ljn+ObuU8/ymVe0Vf/h6iveOHWulsHxKAKs=",
+   "pom": "sha256-kZPQe/T2YBCNc1jliyfSG0TjToDWc06Y4hkWN28nDeI="
+  },
+  "com/google/guava#listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+   "jar": "sha256-s3KgN9QjCqV/vv/e8w/WEj+cDC24XQrO0AyRuXTzP5k=",
+   "pom": "sha256-GNSx2yYVPU5VB5zh92ux/gXNuGLvmVSojLzE/zi4Z5s="
+  },
+  "com/google/inject#guice-parent/5.0.1": {
+   "pom": "sha256-kDu7L7hYTDqztTJVbC+o0IYMXnTGZ/ZoFyC0RbIiYzc="
+  },
+  "com/google/inject#guice-parent/5.1.0": {
+   "pom": "sha256-Y9XAxkF5feumwFHEfV9pI/OhA+9x5OvDqF0Bw+h4WWw="
+  },
+  "com/google/inject#guice/5.1.0": {
+   "jar": "sha256-QTDlC/rEgJnIYPDZA7kYYMgaJJyQ84JF+P7Vj8gXvCY=",
+   "pom": "sha256-s7jcZSE9Yj+3DteVjb3WFjJCVrqDajFlJWDDiJmf2c0="
+  },
+  "com/google/inject/extensions#extensions-parent/5.0.1": {
+   "pom": "sha256-w1gP7P/U4hQ/AYYmjah+5midgreR59J00h3yFuo4olg="
+  },
+  "com/google/inject/extensions#extensions-parent/5.1.0": {
+   "pom": "sha256-dNWnz78WV014/SeLz7YatGyZzY3vw2sFqd0VVWYNVlQ="
+  },
+  "com/google/inject/extensions#guice-assistedinject/5.1.0": {
+   "jar": "sha256-b4dThU0xXaLrO5LhJKgmgtYpLNc63vEyndjsISUzPtM=",
+   "pom": "sha256-mv46KWniWo/DqKZRkLYfsMgwMzE4LZV4Vs+mv+zIzkI="
+  },
+  "com/google/inject/extensions#guice-testlib/5.0.1": {
+   "jar": "sha256-0e7BdJhDRasESjYZVEUmY1mK5GO7F0SAmLUabVcQfsM=",
+   "pom": "sha256-vzBM8BCS+ovTk/tAcpFTg3HAg00L9fcgNTvL4O30zpQ="
+  },
+  "com/google/inject/extensions#guice-throwingproviders/5.0.1": {
+   "jar": "sha256-JNA+qQzw4iiPeDNevdpVUbYCXyHtwoBL/TaJfbKONrk=",
+   "pom": "sha256-Itl4g/3tU9n+22wBMOddFlf+Qjbyz27SdHdFi1iGCOM="
+  },
+  "com/google/j2objc#j2objc-annotations/1.3": {
+   "jar": "sha256-Ia8wySJnvWEiwOC00gzMtmQaN+r5VsZUDsRx1YTmSns=",
+   "pom": "sha256-X6yoJLoRW+5FhzAzff2y/OpGui/XdNQwTtvzD6aj8FU="
+  },
+  "com/google/protobuf#protobuf-bom/3.23.3": {
+   "pom": "sha256-wWRNKPDtuwX/uVjYU6TIRs6p8l8ztytokMKHU9triU4="
+  },
+  "com/google/protobuf#protobuf-java/3.23.3": {
+   "jar": "sha256-Bb7cPdTzHE+tAxwsZ26eK51zz+mACgkYaOSnv2y6rG0=",
+   "pom": "sha256-H7NwKsjQxsDDSB5uyuax/MaxLKUckd9cdzT8dqaleuE="
+  },
+  "com/google/protobuf#protobuf-parent/3.23.3": {
+   "pom": "sha256-e9+EWrQjKoiJZ0W7kkwfYnzmwHc5KK52ye77T/738hs="
+  },
+  "com/google/truth#truth-parent/0.45": {
+   "pom": "sha256-KHUE9L/HYNEjU5JSG9C7ZFFExBEEswLSAv2/z59Ih7Q="
+  },
+  "com/google/truth#truth/0.45": {
+   "jar": "sha256-D33O0qFuVad+RPw/+cW+mNS/S7MKvBjXj/1zXflQpp8=",
+   "pom": "sha256-5qM0fIQv9l+9sQFpFGlZ3Ky8qmIQQ3y7cUeUU0BQMAc="
+  },
+  "com/googlecode/java-diff-utils#diffutils/1.3.0": {
+   "jar": "sha256-YbpNxJrcqVJDvqoFaa3CojrttSkq54qgEYb6eC69xcI=",
+   "pom": "sha256-L+Md1jCbD18ZW73EdJz8CvBl1h8Gz+GD39LyCSq4R7Y="
+  },
+  "com/h2database#h2/1.4.197": {
+   "jar": "sha256-N/UhbhSvJ3KTDf+bhzQ1PwqA6Juj8z4GVEHeZTfF6EI=",
+   "pom": "sha256-xfuHLGFZqbk6a9USF1PmF3qheu7dBKKlSxTuoW+J3BQ="
+  },
+  "com/ibm/etcd#etcd-java/0.0.22": {
+   "jar": "sha256-XxK083FE4AgeiWFr/r15iOd5Kq9QXh1IwsSGcOfkXVA=",
+   "pom": "sha256-+5OMkp3eUzCmk+U7/8dXSKy9umWMp0JheKp5gOowTLg="
+  },
+  "com/moandjiezana/toml#toml4j/0.7.2": {
+   "jar": "sha256-9UdeY+fonl22IiNImux6Vr0wNUN3IHehfCy1TBnKOiA=",
+   "pom": "sha256-W3YhZzfy2pODlTrMybpY9uc500Rnh5nm1NCCz24da9M="
+  },
+  "com/puppycrawl/tools#checkstyle/9.3": {
+   "jar": "sha256-BGPjBJgPVGC5ZPSBzMJaEPslO2AQDBnlD8mSiSiVl38=",
+   "pom": "sha256-p9y0ZmVtZ/oKUNkE/d8U/GtTmEa4FO3/djXHRdW9MDQ="
+  },
+  "com/squareup/okhttp3#logging-interceptor/4.10.0": {
+   "jar": "sha256-JzuiGGNsNPegkcBZ0VlgBUPgPqi+7yxfxWUltHOWFg4=",
+   "module": "sha256-/MsMrtTFnKXjEketzz+Zu9FeWn8NI8me4UbeMd0BhSI=",
+   "pom": "sha256-t/v3nfpIMFDEygZTdhoh0A1YWBkVUHo9nVGctmJgv98="
+  },
+  "com/squareup/okhttp3#okhttp/4.10.0": {
+   "jar": "sha256-dYDxT6FpEgbjcIGtP5IGOxYDsyjaC7MW8v7wLgVi5+w=",
+   "module": "sha256-bDBwggtZH17IwpSEl7Wmt0L0krcVvKz0t1EVs6j/qxU=",
+   "pom": "sha256-x/kgsofIOOHYHipj+Gd7svqZE3BYorEeZTWv3pyBoOU="
+  },
+  "com/squareup/okio#okio-jvm/3.0.0": {
+   "jar": "sha256-vmSgzB8o6pzVyXDdfnVXr3LICNc4xJWzl7+JfJkh6Qc=",
+   "module": "sha256-F/SNQXdb2E3qeOnf7Y37zGavgFZ6XJ7J2WCHheyCDN4=",
+   "pom": "sha256-sMtzRExjeVg7KlOiZIxI3kIOsfSRVmdTdNimdW7zovo="
+  },
+  "com/squareup/okio#okio/3.0.0": {
+   "module": "sha256-b546eXgx51xbVi2UbAdRg/myvoRnken4i95FSR2u2Yc=",
+   "pom": "sha256-lgrVNSNexh9VRtuBPQGVwTr4UjChLqvpmXUeilUNFU8="
+  },
+  "commons-beanutils#commons-beanutils/1.9.4": {
+   "jar": "sha256-fZOMgXiQKARcCMBl6UvnX8KAUnYg1b1itRnVg4UyNoo=",
+   "pom": "sha256-w1zKe2HUZ42VeMvAuQG4cXtTmr+SVEQdp4uP5g3gZNA="
+  },
+  "commons-codec#commons-codec/1.15": {
+   "jar": "sha256-s+n21jp5AQm/DQVmEfvtHPaQVYJt7+uYlKcTadJG7WM=",
+   "pom": "sha256-yG7hmKNaNxVIeGD0Gcv2Qufk2ehxR3eUfb5qTjogq1g="
+  },
+  "commons-collections#commons-collections/3.2.2": {
+   "jar": "sha256-7urpF5FxRKaKdB1MDf9mqlxcX9hVk/8he87T/Iyng7g=",
+   "pom": "sha256-1dgfzCiMDYxxHDAgB8raSqmiJu0aES1LqmTLHWMiFws="
+  },
+  "commons-logging#commons-logging/1.2": {
+   "jar": "sha256-2t3qHqC+D1aXirMAa4rJKDSv7vvZt+TmMW/KV98PpjY=",
+   "pom": "sha256-yRq1qlcNhvb9B8wVjsa8LFAIBAKXLukXn+JBAHOfuyA="
+  },
+  "info/picocli#picocli/4.6.2": {
+   "jar": "sha256-R1TZbq9TFPNaKH2lxnhIsoUGeGj8ptH1Ehp09n8GW2E=",
+   "pom": "sha256-3q4p2lxR4/6dla9ujzkVbCvBt0niQtATbp4jIINIF5k="
+  },
+  "info/picocli#picocli/4.7.4": {
+   "jar": "sha256-GWTolXW0OqF3qk5TSUayW96fOkipZ11h2e98TKg9lLQ=",
+   "pom": "sha256-zU/coxGJvivpwmhAuKOUUDXZPXnHBVD15E7s18rHy70="
+  },
+  "io/fabric8#kubernetes-client-api/6.7.2": {
+   "jar": "sha256-6zs/CAnO8mzKNFPU6+oikKwy2PYxRJ2r/ykHZkyIdko=",
+   "pom": "sha256-2Soucrg7IFJ97EA9wiPnXj7p01oU28mUbVyQXwR3wm0="
+  },
+  "io/fabric8#kubernetes-client-project/6.7.2": {
+   "pom": "sha256-Eoj6iz94vFAgG4V+dxGE4udYob5Is13RhR/iLmL5Mtc="
+  },
+  "io/fabric8#kubernetes-client/6.7.2": {
+   "jar": "sha256-ThPYJDS6NfuRlZPzKKr2/bIR5KpVvBuXY69dC8e/MmQ=",
+   "pom": "sha256-TTtQCC2fC5HltNr2vUSzl1SMeoUuXTL2SCDB+u7X0RY="
+  },
+  "io/fabric8#kubernetes-httpclient-okhttp/6.7.2": {
+   "jar": "sha256-yvZmb3qXdj9xfJ4oQE0p+yi8XJmN3vmvPVbWu9D7V9k=",
+   "pom": "sha256-4TqI4J40aYRg0goOEdGPAbVPSgO7cRmfL5CxUT43FqM="
+  },
+  "io/fabric8#kubernetes-model-admissionregistration/6.7.2": {
+   "jar": "sha256-f51lhZwRbaPSYCmm/D3R8T8P+6sg2HlGswRbd5UIk/4=",
+   "pom": "sha256-dDeJVY9uE1MjS93KghTOjZbYtecTTPR6MLXec5Fq05s="
+  },
+  "io/fabric8#kubernetes-model-apiextensions/6.7.2": {
+   "jar": "sha256-g3Wd/HSH8JQKH7Lv/1v/bbrsqzMDmR21sVBSmXbgZ60=",
+   "pom": "sha256-mYRCKQE2M3/b8tooYtzVN+3WwsuTK9Cf3lmQsFrCTv4="
+  },
+  "io/fabric8#kubernetes-model-apps/6.7.2": {
+   "jar": "sha256-6Sxs8Xc6TMrDqDLQVTjiojopVmpNDBRyd/+98UbLsxw=",
+   "pom": "sha256-oFETUkX/IAgNRdlVLRskAvDDjRby8eP68qVV8AgIBQA="
+  },
+  "io/fabric8#kubernetes-model-autoscaling/6.7.2": {
+   "jar": "sha256-cWA3dMQRggRuoM+B9Rv0mdAnQJx1kTzAdObAgjI+CIE=",
+   "pom": "sha256-+YfP+lNLwp8T0ZT0BJOQUXyI8ZxUD7hiyLDwx12LGqU="
+  },
+  "io/fabric8#kubernetes-model-batch/6.7.2": {
+   "jar": "sha256-6DEcd1cmw7c71BIC7ll78wlX7zyYe27h0IfvTiC+97A=",
+   "pom": "sha256-AZvZvnSa5ZcDJsqcjt94Xt0/AbbZmFXm9wZehWQ9mgI="
+  },
+  "io/fabric8#kubernetes-model-certificates/6.7.2": {
+   "jar": "sha256-yNQew6hXcPzw20079rqmzzcH3b9nV+FmVY7SKbO3jmQ=",
+   "pom": "sha256-N7Y3j9pZxC03SpZ6mfLBTSkHSkQAPtHKUWumrl+EHpU="
+  },
+  "io/fabric8#kubernetes-model-common/6.7.2": {
+   "jar": "sha256-YemRQWP5/nAT7Pb0lqB80+ctcF1VWecJZKNdKnP+VgU=",
+   "pom": "sha256-qE8hyylk20G7pn9FboMrbja03TTe2YVrPyNIKmpBsyI="
+  },
+  "io/fabric8#kubernetes-model-coordination/6.7.2": {
+   "jar": "sha256-qkjK4AVW/4tezGmfv3CNHwa0e0ukVlngprrNkczYdnM=",
+   "pom": "sha256-bmWWpeTLd5nICYO2axE6CbX0D6xDSzsSaXj52wTgzlg="
+  },
+  "io/fabric8#kubernetes-model-core/6.7.2": {
+   "jar": "sha256-KGmrbX1X70GoDRVr4R6N0AhC1Bw84Ut5m8HI+OuMtmw=",
+   "pom": "sha256-TftU7jz3oIdFncNZdTqlHUbLMbEK6+zKC1XC4YoOrW0="
+  },
+  "io/fabric8#kubernetes-model-discovery/6.7.2": {
+   "jar": "sha256-8CF7hxFtkshymBYygVCyLcZtsowhWhd85MyDofN5Huo=",
+   "pom": "sha256-bWYTr5rf2Y0HliXDmPU6rvki3JYIX/UPLe4mSnRGRz4="
+  },
+  "io/fabric8#kubernetes-model-events/6.7.2": {
+   "jar": "sha256-B+uvU+vRmVmSNUvQpFXD2pui1tY4DferllT5Ii5qtco=",
+   "pom": "sha256-Z6ryEual/22fVHfvnjjTeBlC0aHQ2TTygTBBdSzpODo="
+  },
+  "io/fabric8#kubernetes-model-extensions/6.7.2": {
+   "jar": "sha256-EyDeRt0wdTO/x2xasaJe9I4ALAmHph1GPTCDn5z9sKw=",
+   "pom": "sha256-wqncUHqTK/Xn7Ojz8wOupRfmdyg3EvJibbJdi/Xz29Y="
+  },
+  "io/fabric8#kubernetes-model-flowcontrol/6.7.2": {
+   "jar": "sha256-eRY6jw8z+pJy6W6Rcax3DcpM25Iq4w32kxCQQYy6YHw=",
+   "pom": "sha256-/tbpfq8nHLxpmrljpPOBBmMytFANKGid/IJWEQorneo="
+  },
+  "io/fabric8#kubernetes-model-gatewayapi/6.7.2": {
+   "jar": "sha256-Il1XbULjy33Nia16wWbfvSCCJi/Zq9ZvyqD38hDsOe8=",
+   "pom": "sha256-uw3Lz7xcciMB2gqkrNsGC2s/I/jAZjjb61RHvWrNLBA="
+  },
+  "io/fabric8#kubernetes-model-generator/6.7.2": {
+   "pom": "sha256-0JG/cHfL1/k9kjctAfwYHZMoqvGbMvEn0I3BVXlyfXk="
+  },
+  "io/fabric8#kubernetes-model-metrics/6.7.2": {
+   "jar": "sha256-y1boXSQ5gqihsE+TZWk3you46iadr/vZyxYQtXXp8iI=",
+   "pom": "sha256-rwlHPCYwRfRxVxHdRE5PXhv9DdxMKDjUEnOQrEWOqP4="
+  },
+  "io/fabric8#kubernetes-model-networking/6.7.2": {
+   "jar": "sha256-XhFdYxuQXoUN4qWylCeynjPrhj6D7kkah+PH1fNlaYI=",
+   "pom": "sha256-6hQ2/0FBTrW+ykUoE1+cjv1+4y4blexDpakUlNwoLkk="
+  },
+  "io/fabric8#kubernetes-model-node/6.7.2": {
+   "jar": "sha256-hpJHBtzaOjgQ6HlnsvNn6jWkFM/HZwEqsES3WpVwM9c=",
+   "pom": "sha256-PTZQyAIw39sEAK5iuJbuvUuUFtZdu4O0OM3u/pG7TdU="
+  },
+  "io/fabric8#kubernetes-model-policy/6.7.2": {
+   "jar": "sha256-JYTQsKYF7VhzKxTWkckLBQToo6AIGczZx1A+9MRleAY=",
+   "pom": "sha256-0hyG5XSxhtfUrH6Nyo39ZYxQtQ9clNJAlZHyArvOuTA="
+  },
+  "io/fabric8#kubernetes-model-rbac/6.7.2": {
+   "jar": "sha256-MGrtmXRJYLKMTe65KuDVNEw1Yul2jKNYMK/SKw/qFc0=",
+   "pom": "sha256-dUeldJ9p/7IDz6VW4tzM6HCXUxNgO6R7ugaOHy/6BzQ="
+  },
+  "io/fabric8#kubernetes-model-resource/6.7.2": {
+   "jar": "sha256-bh59oDyeRc8s25sk3Gw1Bkd2xCCGWTyHNArBKq0X4Qk=",
+   "pom": "sha256-+KMTqp7QVdsqT6bLrnR5urCTUC2c5aWyeEaznmN9rx8="
+  },
+  "io/fabric8#kubernetes-model-scheduling/6.7.2": {
+   "jar": "sha256-IY3OMrZb1NmkCfJZNWImVk4uW0S0SMjojfpT8p544fw=",
+   "pom": "sha256-s2bywdeyUpZpUGnahrXVHsS01qwgNAkmkp9OftKyhF8="
+  },
+  "io/fabric8#kubernetes-model-storageclass/6.7.2": {
+   "jar": "sha256-qVR5twboGnkl+doGvNPf9isjdAsEcewouBPFJNSaZh8=",
+   "pom": "sha256-E3kRmVu2OSFSgxxZ0TdmiEEmBkWeSX3YfzPVCB0uivI="
+  },
+  "io/fabric8#zjsonpatch/0.3.0": {
+   "jar": "sha256-rk5ekxZGolywm1UYbeTzNG41jgETC+8nnd9JWnGccdU=",
+   "pom": "sha256-Jv23lFbWkVQJaF1G9Gf3LUEKCFGkQLRRCebu8klrCz0="
+  },
+  "io/grpc#grpc-api/1.50.0": {
+   "jar": "sha256-24xk33FfVA7i33ZIb2hhOHGXhvHiU/rT1hUVGih7XkU=",
+   "pom": "sha256-/2zk09ibfesR0uO1gF3b/dX+zbe2iSHINHatldP0Vck="
+  },
+  "io/grpc#grpc-context/1.50.0": {
+   "jar": "sha256-BBVvetESNZAKd+vTSOcQrXag0svv3lJ8H5Czj7oa6Qg=",
+   "pom": "sha256-2HB4jC/ZiHxoPPhB1UJUEPd81VzqXqOJzjWIEaXl3vo="
+  },
+  "io/grpc#grpc-core/1.50.0": {
+   "jar": "sha256-kBJRmEh+fKlMXzaX9RC3Vg10D9xZvNawNH30KaU8ZZo=",
+   "pom": "sha256-JQp9xaMy2nB+aWNVpWIo8VnrSnr392IOAlUc2xdWpFQ="
+  },
+  "io/grpc#grpc-netty/1.50.0": {
+   "jar": "sha256-AEz2WbB5u6tgR5adCMqY7BP2+JLOywhMH/ohk6jm95k=",
+   "pom": "sha256-fxv43OelTV9bJImDtw5yLp0uNkidgKC59gBwhRltSy4="
+  },
+  "io/grpc#grpc-protobuf-lite/1.50.0": {
+   "jar": "sha256-moPeFedyJpA9V4mogYfC+4dMKasmqG+xuhNy5mUwvDI=",
+   "pom": "sha256-rAFUAUMrYESP+J08OC9umLGwCEe202P8LtJGZyUdx0s="
+  },
+  "io/grpc#grpc-protobuf/1.50.0": {
+   "jar": "sha256-xVG5Y9bmZNEAjkFYWrVDdcw+gQsMq9WMRr58C+09BHI=",
+   "pom": "sha256-witYAS96Zq7AFmPkjGBtRvtzGs6MiARXywmANiDcfkc="
+  },
+  "io/grpc#grpc-stub/1.50.0": {
+   "jar": "sha256-ZOaTsTqOz15Tyy0bZlA+MirA3ZYDk2IEt/cU9gV47IM=",
+   "pom": "sha256-Uub3yWxKfLHr3hzYq3zeUvvgkvesIe8Xq6ETC7p3U8E="
+  },
+  "io/netty#netty-buffer/4.1.79.Final": {
+   "jar": "sha256-U7PJnAJfc0SWDYpBDfV5LKukRE3YLBhgalcvc2ESf5g=",
+   "pom": "sha256-bZlfBTMUtfV9GWwWdIM4PFOqe41iAWTNqLolTF6mRLc="
+  },
+  "io/netty#netty-codec-http/4.1.79.Final": {
+   "jar": "sha256-FueFBA+NDDnprlGUtlJ8ifXhURa7pK1/T8d2zbG5KRg=",
+   "pom": "sha256-LeaWm0fBfEaAFPCRCUNRgRtxJYYLR2QgXDL4TUZNwfo="
+  },
+  "io/netty#netty-codec-http2/4.1.79.Final": {
+   "jar": "sha256-nnZ6kEsKq5xEqqyUer8JEQVfNBRZUgslA8cBSkY1x/g=",
+   "pom": "sha256-8fQPs0DIwiGbJACB8woGbupe36ssvZSfZWVaLWTFmD4="
+  },
+  "io/netty#netty-codec-socks/4.1.79.Final": {
+   "jar": "sha256-YY/eJT3ac6A5ubeugTw0VwxOx82VFCwqRGAqmIt4nwA=",
+   "pom": "sha256-nqQY2p7WpN+QoeeVjkVAEFH2VV4saScW3O1FYE2Ipck="
+  },
+  "io/netty#netty-codec/4.1.79.Final": {
+   "jar": "sha256-qA3LeQd9IXow2MnkPB2ld7ZC8eb7GqgLwis+uHK1Zd4=",
+   "pom": "sha256-O1jnbUhRph3BvvXzvA/79mWcjq/X641TaQJ/jXw9DKQ="
+  },
+  "io/netty#netty-common/4.1.79.Final": {
+   "jar": "sha256-Gg2jfpbbxBu+VvwR5iGhcY7ysx9rzD9Im6LSLCNeajw=",
+   "pom": "sha256-aNc124KK330uqEmb/2vIoiIHelqVj04MbGKqzCtv7Mg="
+  },
+  "io/netty#netty-handler-proxy/4.1.79.Final": {
+   "jar": "sha256-mabuX/PrOMqlxbIVgmYGhWtW3AQNiI9pEW2cbbiHCa4=",
+   "pom": "sha256-otRsnyMTagolBPFxkZSKQziT5mnV5IP+fRSqoK8cNlQ="
+  },
+  "io/netty#netty-handler/4.1.79.Final": {
+   "jar": "sha256-th9WMK9rPNThiIXF/eL4ZDqY/gPlKeBfiL/oCuPL1x4=",
+   "pom": "sha256-kJnpyXKtIHQ92tnzpsEXyaJ3hO3NIeHrIFiubMYbRh8="
+  },
+  "io/netty#netty-parent/4.1.79.Final": {
+   "pom": "sha256-/TKD51iC3KlAFVlsg8/6WkFF2nSWfreO22muUMAcyVM="
+  },
+  "io/netty#netty-resolver/4.1.79.Final": {
+   "jar": "sha256-xsERoze7azqInOqzIelHPaSaTiYdz0IvyiIoQGTjgTA=",
+   "pom": "sha256-Zxho9Gfp1rHtkIk/rhoJ7DmqJpic7KhsbC+otbWO+lw="
+  },
+  "io/netty#netty-tcnative-boringssl-static/2.0.54.Final": {
+   "jar": "sha256-G5ru4qd1MU65cvl+MOk9zBRywJ8OSkPD/nr6ki5mneo=",
+   "pom": "sha256-hnQWfKzK0u6CpshXiyPNUKN8DBnCbbX57Rw8WuYB5jk="
+  },
+  "io/netty#netty-tcnative-classes/2.0.54.Final": {
+   "jar": "sha256-mJd+J5pmd46Bbw7SXqW30gsc/8ZGnec+Xj6azNoqzrQ=",
+   "pom": "sha256-vWnrbGPHkjEraWWMW/SRrp2mm+AnTUWjt2e+sTELcMU="
+  },
+  "io/netty#netty-tcnative-parent/2.0.54.Final": {
+   "pom": "sha256-QTIpqX5YxD//el9+z9NXF6SBveIe1FEAZ3nzM82kFes="
+  },
+  "io/netty#netty-transport-classes-epoll/4.1.79.Final": {
+   "jar": "sha256-LRAC8HxDn8NworGdKg+i0eIwtd/YckU/5qRx6NOY1H4=",
+   "pom": "sha256-VKE68wkTTmC5y7qnD4M71qSDC0hLxO6sRv/lzGhBZIA="
+  },
+  "io/netty#netty-transport-native-epoll/4.1.79.Final": {
+   "pom": "sha256-1w67Wmc9rMy31BEj0G00VT3XwQ3ZvVFW+HvA0Zvr4SA="
+  },
+  "io/netty#netty-transport-native-epoll/4.1.79.Final/linux-x86_64": {
+   "jar": "sha256-gu/cjJsM5qN+m0NiLOHjGHKH274b2YfLzO6WS+P8BwY="
+  },
+  "io/netty#netty-transport-native-unix-common/4.1.79.Final": {
+   "jar": "sha256-WwF92WAK9l6hdGo7Utq9ge5L89+bUJCdtPtJ/LNZKXA=",
+   "pom": "sha256-l4TY+nMYpwIHKILdtznJ3ylakSWc/RhNQCBbti8gohw="
+  },
+  "io/netty#netty-transport/4.1.79.Final": {
+   "jar": "sha256-cc+ZtsNoW2Svmx3hYbI/EH186Ad6lZIffccMolg48DQ=",
+   "pom": "sha256-J48YhHPfpOph6B2gnpSFN677LNfLk/nOL8x68iGVA3U="
+  },
+  "io/perfmark#perfmark-api/0.25.0": {
+   "jar": "sha256-IERUKTP830CtGEQb7DdkbRUMSRhxFX8oiEfinLgd5Ms=",
+   "module": "sha256-IpYf8LYmpm0eXq2j6fro0q00UUdiXeWtpzvLOoa1nw0=",
+   "pom": "sha256-GkorgozQuQBBYmvewik/3GqYkBZh4wtf41hbn8lLCOo="
+  },
+  "io/projectreactor#reactor-bom/2022.0.8": {
+   "module": "sha256-/swv+DKg0IE9tFYTLYw/pEar1gJL0X89RODQVcKSmY4=",
+   "pom": "sha256-1cu/8LVPQPD6+Xq9rosFVqt1LuBMeQeZteeS6a3J/dk="
+  },
+  "io/projectreactor#reactor-core/3.3.12.RELEASE": {
+   "module": "sha256-MKZlRKXs1g5hOJH0DVCiTfXJyiN+A/fjtjL8NrnAUGM=",
+   "pom": "sha256-u6REXu0hwOYAZCdcd22KHc0isBIOYDR/ks4iQUtpDUo="
+  },
+  "io/projectreactor#reactor-core/3.5.7": {
+   "jar": "sha256-ZYHYRMNbs4wXps5P3IDrxkpHzp/g1/cewLp3g0GGltE=",
+   "module": "sha256-SbbmVYxWPl2CgYMsvQSm3fsRK9Ra7yycn432bG5F7Ac=",
+   "pom": "sha256-6SAnLIUObNt5NgFdURKjRpoEKVaccEspghdx07d0EII="
+  },
+  "io/projectreactor#reactor-test/3.3.12.RELEASE": {
+   "module": "sha256-uyL/BEgJ2K8Grf+L75gw/cvY2sEoYAZnopVLXt5wSxQ=",
+   "pom": "sha256-l3TT8Utx/t/CmjiaREVQxNPxhX9lbM8/ffc7FqrujVc="
+  },
+  "io/projectreactor#reactor-test/3.5.7": {
+   "jar": "sha256-8BQqxsLhAvA29cQYMPF0QfF36R/xF7FTxpAYbVgBBjc=",
+   "module": "sha256-9lVOZX8acPIfGur86TqT1S0mCvYtfB0f4wH5X6KRguA=",
+   "pom": "sha256-60GMltYmMp29yMFzM4vLgYhN3cc5r5fJaHsxtFuF3mk="
+  },
+  "io/prometheus#parent/0.16.0": {
+   "pom": "sha256-citVEZCXsE1xFHnftg3VSye1kgoa63cCAnxEohX/xZY="
+  },
+  "io/prometheus#simpleclient/0.16.0": {
+   "jar": "sha256-IsN08jf3vE/bHw7C2jecC6AOaa0v/otq3lQ9cwYtN38=",
+   "pom": "sha256-/sCA0HqxWHXZccSugflR2mG1z/mZHPUOUwuo/KR3CXM="
+  },
+  "io/prometheus#simpleclient_common/0.16.0": {
+   "jar": "sha256-66bsJs5+QMu4cl4F+4Mkep9PRJRbnnUi4zdd3me58Fk=",
+   "pom": "sha256-d/ARCc4VB710Q+InJzdnSydST6rLDcuW47jt4LarnrY="
+  },
+  "io/prometheus#simpleclient_hotspot/0.16.0": {
+   "jar": "sha256-E08VbP60TL04ZAZYBu9dtVQ8aK9XjR1+5ZKD4umFP3M=",
+   "pom": "sha256-0haTfecjEg+3pMiLksW+oZEa+4i6dtDUjxdprYW2dek="
+  },
+  "io/prometheus#simpleclient_tracer/0.16.0": {
+   "pom": "sha256-OBK7IrlfgbTDRg6eTnXDunL6ReRDqfzlMghCqr0OmcI="
+  },
+  "io/prometheus#simpleclient_tracer_common/0.16.0": {
+   "jar": "sha256-6Ep4SsjiTxgu5i2oC2tcgUB3S3W/pL+cw9O4OQ22JfY=",
+   "pom": "sha256-X5AHXOz80RKB3pzLSJaNEhKyRnDWhP/IQEQaUq6HXv8="
+  },
+  "io/prometheus#simpleclient_tracer_otel/0.16.0": {
+   "jar": "sha256-oqhMWb7zeWu3+cbyrot96LkFMT7ygYCsPef/Yd1o3z8=",
+   "pom": "sha256-frl58dwz6L5OWtFDDlQJcYpBeDwmd5qzEFJg9rQ20EY="
+  },
+  "io/prometheus#simpleclient_tracer_otel_agent/0.16.0": {
+   "jar": "sha256-etK7QN90p3LZ9URaPQNXm0nWs3pH1ekPbPP1ns9BrQY=",
+   "pom": "sha256-VSj4WIQ1SulNm8BnR+f1iS0JLAtVBVrnBWZo6gyhznw="
+  },
+  "io/sentry#sentry/5.6.1": {
+   "jar": "sha256-KSxX2Iut25qm3l6FYCX1wyva5bN7TdXa8WLcEclHrJU=",
+   "pom": "sha256-1GI9JmsnQdoycXdHawr3asr4JyLrOp2EdOMmKudDeMY="
+  },
+  "jakarta/annotation#ca-parent/1.3.5": {
+   "pom": "sha256-vbsElGXzZu21pK2/8pOoQcm3WyOFGedvhv5Pe/udfi0="
+  },
+  "jakarta/annotation#jakarta.annotation-api/1.3.5": {
+   "jar": "sha256-hfsD/AVM3078qO/ZtnEru0GOGrmCQcRTnIWFu8I+G4o=",
+   "pom": "sha256-umh0dn9UFcXg9kT6uA4brV/qttGBUPImOAZ2gYZv6q8="
+  },
+  "jakarta/servlet#jakarta.servlet-api/4.0.4": {
+   "jar": "sha256-WG4ncGwhJY9YgvQ74GkE9JsC25rFTjRdOT/koySU0Sc=",
+   "pom": "sha256-adOGRepXhbdsKZiQII7R3Du5FSWR69ICX2GT3XzrPSc="
+  },
+  "jakarta/validation#jakarta.validation-api/2.0.2": {
+   "jar": "sha256-tC1CQo89kiyJKpCfoEMofVd8DFsWWtm31WjOv4f8nqQ=",
+   "pom": "sha256-Oy5Oh3+3C6+h2tdcDemZxFYTEoLUcbpR3z25bDt02pI="
+  },
+  "jakarta/ws/rs#jakarta.ws.rs-api/2.1.6": {
+   "jar": "sha256-TOopnIRsim5kcMv8L3w5G8KbnKovkmSsEGS6kWkfSt8=",
+   "pom": "sha256-KRwYptzFR2Y5d3SlwSoryaLzN/Su1i0/n79sBkg7HzY="
+  },
+  "javax/activation#activation/1.1.1": {
+   "jar": "sha256-rkdRIOn82ZtLALODKb1hzcXrdU7uA/5mwB9Q4TdyT5k=",
+   "pom": "sha256-I4FJ4En7vEM06sjt1ZzKVlp1COKDmEHn02zSaBFY//A="
+  },
+  "javax/annotation#javax.annotation-api/1.3.2": {
+   "jar": "sha256-4EulGVvNVV3JVlD3zGFNFR5LzVLSmhC4qiGX86uJq5s=",
+   "pom": "sha256-RqSiUcpAbnjkhT16K66DKChEpJkoUUOe6aHyNxbwa5c="
+  },
+  "javax/inject#javax.inject/1": {
+   "jar": "sha256-kcdwRKUMSBY2wy2Rb9ickRinIZU5BFLIEGUID5V95/8=",
+   "pom": "sha256-lD4SsQBieARjj6KFgFoKt4imgCZlMeZQkh6/5GIai/o="
+  },
+  "joda-time#joda-time/2.8.1": {
+   "jar": "sha256-tGcLlfdZV8l0KExfOtqWYEC+JXj2Q8XGCD0mIWIGH6I=",
+   "pom": "sha256-GLpc/f+WCR4AGYlTYURgedkSNe5WbLHUl2OcGs5inXg="
+  },
+  "junit#junit/4.13.2": {
+   "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
+   "pom": "sha256-Vptpd+5GA8llwcRsMFj6bpaSkbAWDraWTdCSzYnq3ZQ="
+  },
+  "junit/junit/maven-metadata": {
+   "xml": {
+    "groupId": "junit",
+    "lastUpdated": "20210213164433",
+    "release": "4.13.2"
+   }
+  },
+  "net/bytebuddy#byte-buddy-agent/1.10.14": {
+   "jar": "sha256-MCchZ+zrHLaPqEcwoS0av9Ha7WrgwZ/e/uR6mpoM/TM=",
+   "pom": "sha256-hxLCKIXhbeaRefkh1QFRZJOnzvZJl5lfxCjn5YsS6o0="
+  },
+  "net/bytebuddy#byte-buddy-agent/1.9.10": {
+   "pom": "sha256-DsB8KT/dqBbPYFS7gd+V4rRT50i62Sxt4VAWI0jmQVI="
+  },
+  "net/bytebuddy#byte-buddy-parent/1.10.14": {
+   "pom": "sha256-H87vFS45Ysj7s6hgEQMkx7FPQXuSWwft9rqZfNz1Lrk="
+  },
+  "net/bytebuddy#byte-buddy-parent/1.9.10": {
+   "pom": "sha256-Kfsj6h40RdEkxCfUGkvVVBxah4nAbTZEeVwltIDw4uo="
+  },
+  "net/bytebuddy#byte-buddy/1.10.14": {
+   "jar": "sha256-DmuTW/yz5FHVJZVqytU+yG/5FtcUq9vTKz0gOXcYlvg=",
+   "pom": "sha256-OznKPV67mrdX+dQtzWtnfIi0go7cp/YHnxG78u887lg="
+  },
+  "net/bytebuddy#byte-buddy/1.9.10": {
+   "pom": "sha256-s9WAeQdFg1PBCsytXLaWg2EU88JniilVod5GtidFvkM="
+  },
+  "net/java#jvnet-parent/3": {
+   "pom": "sha256-MPV4nvo53b+WCVqto/wSYMRWH68vcUaGcXyy3FBJR1o="
+  },
+  "net/java/dev/jna#jna-platform/5.12.1": {
+   "jar": "sha256-jOlpEWyslb1hsHqNXgcXSzUuYzAUc8qscsOV48CEiNI=",
+   "pom": "sha256-wnn/o7UWjiIDCHIxxjiRmnzsdFgAaxzaZpWXR4YPtFc="
+  },
+  "net/java/dev/jna#jna/5.12.1": {
+   "jar": "sha256-kagUrE9A1g3ukdhC4aith0xiGXmEQD0OPDDTnlXPU7M=",
+   "pom": "sha256-Zf8lhJuthZVUtQMXeS9Wia20UprkAx6aUkYxnLK4U1Y="
+  },
+  "net/sf/saxon#Saxon-HE/10.6": {
+   "jar": "sha256-bQjfguTthrarsaAse3SiaPz8XgBOg7tP8AbsOlCb01Y=",
+   "pom": "sha256-otbdpDjoZKuTXzG0O1MFLE6HEalQVkJxkZBRPnb0Ekg="
+  },
+  "org/antlr#antlr4-master/4.9.3": {
+   "pom": "sha256-VlzAVNO631DKCgcX2uMRJootZwn93ckKxKQ8YtAZNbk="
+  },
+  "org/antlr#antlr4-runtime/4.9.3": {
+   "jar": "sha256-ExpllJabxPMh1lLqKjO8DjeMoxJoXvh3kbLGCynQHqU=",
+   "pom": "sha256-T35E5OoGKfo6dZsRFv65+yiBTpX3keHu7dIMEoideqQ="
+  },
+  "org/apache#apache/13": {
+   "pom": "sha256-/1E9sDYf1BI3vvR4SWi8FarkeNTsCpSW+BEHLMrzhB0="
+  },
+  "org/apache#apache/16": {
+   "pom": "sha256-n4X/L9fWyzCXqkf7QZ7n8OvoaRCfmKup9Oyj9J50pA4="
+  },
+  "org/apache#apache/19": {
+   "pom": "sha256-kfejMJbqabrCy69tAf65NMrAAsSNjIz6nCQLQPHsId8="
+  },
+  "org/apache#apache/21": {
+   "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
+  },
+  "org/apache#apache/23": {
+   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
+  },
+  "org/apache#apache/27": {
+   "pom": "sha256-srD8aeIqZQw4kvHDZtdwdvKVdcZzjfTHpwpEhESEzfk="
+  },
+  "org/apache/commons#commons-dbcp2/2.7.0": {
+   "jar": "sha256-syEXE1h2/0hOVuJeNZzM9sqEzOeyjIWobetTvBZtGuA=",
+   "pom": "sha256-jvm6SmpAKn8SY4ncNYlCrxWzcs7NMdC0fohbYUWJIEE="
+  },
+  "org/apache/commons#commons-parent/34": {
+   "pom": "sha256-Oi5p0G1kHR87KTEm3J4uTqZWO/jDbIfgq2+kKS0Et5w="
+  },
+  "org/apache/commons#commons-parent/39": {
+   "pom": "sha256-h80n4aAqXD622FBZzphpa7G0TCuLZQ8FZ8ht9g+mHac="
+  },
+  "org/apache/commons#commons-parent/47": {
+   "pom": "sha256-io7LVwVTv58f+uIRqNTKnuYwwXr+WSkzaPunvZtC/Lc="
+  },
+  "org/apache/commons#commons-parent/48": {
+   "pom": "sha256-Hh996TcKe3kB8Sjx2s0UIr504/R/lViw954EwGN8oLQ="
+  },
+  "org/apache/commons#commons-parent/52": {
+   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
+  },
+  "org/apache/commons#commons-pool2/2.7.0": {
+   "jar": "sha256-a1TGdcc4fhV9KMcJiHPy53LCI8ejW8mxNxc2fJdToeQ=",
+   "pom": "sha256-9CIA1rGpIpvazPuYkIAG1zMPijV0RXjz6y0sj9VURsA="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.13": {
+   "jar": "sha256-b+kCalZsalABYIzz/DIZZkH2weXhmG0QN8zb1fMe90M=",
+   "pom": "sha256-eOua2nSSn81j0HrcT0kjaEGkXMKdX4F79FgB9RP9fmw="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.13": {
+   "pom": "sha256-nLpZTAjbcnHQwg6YRdYiuznmlYORC0Xn1d+C9gWNTdk="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.4.13": {
+   "pom": "sha256-xVTnAI5FF8fvVOAFzIt09Mh6VKDqLG9Xvl0Fad9Rk2s="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/11": {
+   "pom": "sha256-qQH4exFcVQcMfuQ+//Y+IOewLTCvJEOuKSvx9OUy06o="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/13": {
+   "pom": "sha256-5Ch4ZwNYVsc3QgNo3VhuXlfnAgmBNYQM89c+nINj17M="
+  },
+  "org/apache/httpcomponents#httpcore/4.4.13": {
+   "jar": "sha256-4G6J1AlDJF/Po57FN82/zjdirs3o+cWXeA0rAMK0NCQ=",
+   "pom": "sha256-j4Etn6e3Kj1Kp/glJ4kypd80S0Km2DmJBYeUMaG/mpc="
+  },
+  "org/apache/httpcomponents/client5#httpclient5-parent/5.2.1": {
+   "pom": "sha256-Dh6u8QHwRZEp9HElsL2UpYObn1TYKyxfNVGlfM74VkE="
+  },
+  "org/apache/httpcomponents/client5#httpclient5/5.2.1": {
+   "jar": "sha256-k1Xzh2uvgv7BPO0iwSti1XU2Iwg2QG01lFkSjk9z7VE=",
+   "pom": "sha256-RlsNajRmSds3SFsPpmBiG0qN+QCGP6GYcJ8ZjVR+G9s="
+  },
+  "org/apache/httpcomponents/core5#httpcore5-h2/5.2": {
+   "jar": "sha256-Wgh/uMYZl51JKoNUbzUd2t8ysozGoykjIp8/x3cXFXg=",
+   "pom": "sha256-WdDu5k/MP0VJqLoeDJnaEl9GQhxo/GPsynL8j28sPuI="
+  },
+  "org/apache/httpcomponents/core5#httpcore5-parent/5.2": {
+   "pom": "sha256-1/fv7GCeD91+OubrOlUAWOb5Pl0sJCTXSyHej3U291A="
+  },
+  "org/apache/httpcomponents/core5#httpcore5/5.2": {
+   "jar": "sha256-KTMhy/WU156ooMsCFPdfFG0X8Ii+F61c4Rwv6GTfEkw=",
+   "pom": "sha256-EHqMsQtc5ARGTq/B9nscEy8GgxDzC4bYpMCkTakFfyU="
+  },
+  "org/assertj#assertj-core/3.18.1": {
+   "jar": "sha256-chq6RRpbEBmYbTjHKDJxc7EW2WHGN8rhWu3PUkut39U=",
+   "pom": "sha256-yY463bLtJCZF2QLqJxxo2t+rDPzFH2vMjYFq8Rkmogs="
+  },
+  "org/assertj#assertj-parent-pom/2.2.8": {
+   "pom": "sha256-ULBWi0yjXw0SQvXUPhh/UyW81ZhQryihKNLlnJmSNGU="
+  },
+  "org/assertj/assertj-core/maven-metadata": {
+   "xml": {
+    "groupId": "org.assertj",
+    "lastUpdated": "20240709170938",
+    "release": "3.26.3"
+   }
+  },
+  "org/checkerframework#checker-compat-qual/2.5.5": {
+   "jar": "sha256-EdE0skXpysxHRRTS1mtbhhj4A5oUZc3FW7wLNOAAi3o=",
+   "pom": "sha256-QvIevZGDvgSe5a/IIrNFQDpdp2QDeHVzSgObDW4DU74="
+  },
+  "org/checkerframework#checker-qual/3.12.0": {
+   "jar": "sha256-/xB4WsKjV+xd6cKTy5gqLLtgXAMJ6kzBy5ubxtvn88s=",
+   "module": "sha256-0EeUnBuBCRwsORN3H6wvMqL6VJuj1dVIzIwLbfpJN3c=",
+   "pom": "sha256-d1t6425iggs7htwao5rzfArEuF/0j3/khakionkPRrk="
+  },
+  "org/checkerframework#checker-qual/3.23.0": {
+   "jar": "sha256-qgmRivovsGlcMpSk/4CjurGCDMYSHPLs001bFsumbXs=",
+   "module": "sha256-E9VFSx5VbpbWtR2oydChv5FAQkQfIKZ/G+t2LaP/L7I=",
+   "pom": "sha256-3BQs+lD0a1+2rr89r6kd3/3DrWMIloSjDPbWClmT5/g="
+  },
+  "org/checkerframework#checker-qual/3.5.0": {
+   "pom": "sha256-KDazuKeO2zGhgDWS5g/HZ7IfLRkHZGMbpu+gg3uzVyE="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.21": {
+   "jar": "sha256-LyWEHJN+JJWaV7Yw4sS4Uls9D1NvLlEcmyvtMLFlHVQ=",
+   "pom": "sha256-zercAJavswjtaEajO4OvpuvyvhurDmZyF2Nf5x8DJK8="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.21": {
+   "pom": "sha256-QmNXp0uOuqGIkiLYFQdDCxgWyjrj9cq34YRQEOgMUfw="
+  },
+  "org/codehaus/mojo#mojo-parent/65": {
+   "pom": "sha256-yJ+0QKWXuD7syhCKxZhRlJNojrAz6FQuUaKwQo2opnY="
+  },
+  "org/eclipse/ee4j#project/1.0.5": {
+   "pom": "sha256-kWtHlNjYIgpZo/32pk2+eUrrIzleiIuBrjaptaLFkaY="
+  },
+  "org/eclipse/ee4j#project/1.0.6": {
+   "pom": "sha256-Tn2DKdjafc8wd52CQkG+FF8nEIky9aWiTrkHZ3vI1y0="
+  },
+  "org/eclipse/ee4j#project/1.0.8": {
+   "pom": "sha256-DQx7blSjXq9sJG4QfrGox6yP8KC4TEibB6NXcTrfZ0s="
+  },
+  "org/flywaydb#flyway-core/7.15.0": {
+   "jar": "sha256-WSTyda9OhOfOFroVRNp6TkhRZvzISgQGAG8q4xhLU1Y=",
+   "pom": "sha256-JTjXcMR7w/j9C+96VkxCQYEceumv7IfmFqr+UOupbaw="
+  },
+  "org/flywaydb#flyway-parent/7.15.0": {
+   "pom": "sha256-v03BqqsekJmAg4qup3qjA0B4aQwjH0ByjEFn1aWIB5k="
+  },
+  "org/glassfish#javax.el/3.0.0": {
+   "jar": "sha256-Xtd7kVDBy2vcGhlbtTbu9utl9G9EEuJsJCiGkOqAM+w=",
+   "pom": "sha256-66+B03k3d+4o0SFxsgw+xc4g9dnawlLy5lIfEmrjwrI="
+  },
+  "org/glassfish/grizzly#grizzly-bom/2.4.4": {
+   "pom": "sha256-0bQI760QZ3/hMTmZxY4rXTQOhB7uWOygM0vK0jO5AXk="
+  },
+  "org/glassfish/grizzly#grizzly-bom/4.0.0": {
+   "pom": "sha256-sBGtBpT08UjUcB7FkO8naziueaqfRrpc+D5vqfFfWls="
+  },
+  "org/glassfish/grizzly#grizzly-framework/4.0.0": {
+   "jar": "sha256-058eL/1/65HyNWGdBD8/HVJms35q9Osl7XAinL1Xzg4=",
+   "pom": "sha256-7qqGp34FRe2D19JH+5lPyqQsXle4t9WCcvjVN8LuEz4="
+  },
+  "org/glassfish/grizzly#grizzly-http-server/4.0.0": {
+   "jar": "sha256-3BVvJIooKFa7LLIy97saAznOy/zg6vpkwxH07j1LOGE=",
+   "pom": "sha256-1QS5Ho98LkjEQEQFXMA76ZN0+EhxA+D5mzCxtkJWQsk="
+  },
+  "org/glassfish/grizzly#grizzly-http-servlet/2.4.4": {
+   "jar": "sha256-372YylZ9SihRslvR72sXFF21A/VPlnnN4ncx1XRw8kY=",
+   "pom": "sha256-qepY8LWavV+XfbSkfqoWEJiBexBHQ9QXNt68M6Tx3NQ="
+  },
+  "org/glassfish/grizzly#grizzly-http/4.0.0": {
+   "jar": "sha256-GxzGMmdZWVqkf/oudgKDmYFqBIBmQFoFYE3xpYlyFyA=",
+   "pom": "sha256-/ZPDVpa12J2z2BwQkGjFdMuqjxfZEcv8HZqdd+mTgOg="
+  },
+  "org/glassfish/grizzly#grizzly-project/2.4.4": {
+   "pom": "sha256-7crBUSxpjis++3uFZElusuUlAcuKZl8xfwXt3PkOjkk="
+  },
+  "org/glassfish/grizzly#grizzly-project/4.0.0": {
+   "pom": "sha256-RFQDYJ3t/bphha7pMt7HCJn67bI0or5UdmcyeMVHfmo="
+  },
+  "org/glassfish/hk2#external/2.6.1": {
+   "pom": "sha256-ZwiY1PI4/ebP14kn6SzX+SpfZF7/fF1q4t2wlQtEhj0="
+  },
+  "org/glassfish/hk2#guice-bridge/2.6.1": {
+   "jar": "sha256-giUtq/WdnbalLrWZDcEk+tTNG98PhztA0/i+UBB5K9U=",
+   "pom": "sha256-mMKp3tjdenx7ClR0vmN3WZtcIyRyDx5IsUWry7ENpOw="
+  },
+  "org/glassfish/hk2#hk2-api/2.6.1": {
+   "jar": "sha256-wsuAoB5YRArlfV7lmvTU2U5RgOBK/xErDLYRwH1h53M=",
+   "pom": "sha256-tG5QJsnTJb9y2EqMkCK9UIuBzxGMpGiZwjzPIweou4s="
+  },
+  "org/glassfish/hk2#hk2-locator/2.6.1": {
+   "jar": "sha256-/rxmjeufIADHa9SRjYCGwKTHTQe9DGBIa3LGvTi2KHQ=",
+   "pom": "sha256-qblLDyIPJor+aAbEkilXpyCDVLfa74voooJFhiH11qg="
+  },
+  "org/glassfish/hk2#hk2-parent/2.6.1": {
+   "pom": "sha256-Nht2+9xsyUgefXVWf8d4lFX0MActomfhKhCGZYtcQwg="
+  },
+  "org/glassfish/hk2#hk2-utils/2.6.1": {
+   "jar": "sha256-MHJ/eQhkUv3v2rCEUdmCwggqojnZ91zesbonHjyIcDY=",
+   "pom": "sha256-dqPfii94CrBivFiaRg4xvrFaTfHkJ/0QZ1IJVcXXuU0="
+  },
+  "org/glassfish/hk2#osgi-resource-locator/1.0.3": {
+   "jar": "sha256-qrXXhJ98/Nosx8VBuhvTZRUdQidvFRyCU4ckXf3j3XQ=",
+   "pom": "sha256-i2Yi64HlVymfvZqoVLxax20wf3rl53BYZImli7Uziyo="
+  },
+  "org/glassfish/hk2/external#aopalliance-repackaged/2.6.1": {
+   "jar": "sha256-utd/knjXU0BjYK+eR0e9mzFhVU6pzT1iQRoK4fLBQf0=",
+   "pom": "sha256-4TAQv+uG1xU3Fol2bhFlRblZ9zhV+zsyjT4m5FFPkLQ="
+  },
+  "org/glassfish/hk2/external#jakarta.inject/2.6.1": {
+   "jar": "sha256-XojBI7PkG8p4iyaDEYhn2bbexxQkfqkcWIrtRqNu4k8=",
+   "pom": "sha256-67cEyRFy3ESpodEpgRfOehdgapDCglewEuObDO+JgzM="
+  },
+  "org/glassfish/jersey#project/2.40": {
+   "pom": "sha256-xwwhEaGjgRL+fTfYNmHo4YxulxQSS7h/bGvRGf0BtAs="
+  },
+  "org/glassfish/jersey/containers#jersey-container-grizzly2-http/2.40": {
+   "jar": "sha256-ZkHU92jQ0cqVi73VcHMdDDSz9ocUcgKcc6OPG2aWD0g=",
+   "pom": "sha256-/CMgiZXfV9LzseFh383VX/XKli8aGIWwwTPQrDIbTi8="
+  },
+  "org/glassfish/jersey/containers#jersey-container-grizzly2-servlet/2.40": {
+   "jar": "sha256-Yh8CSIIYr6B7mNCD8Zex4H9UOgjQMPbaav83roA31M4=",
+   "pom": "sha256-T46BXnS07Eo4kg3FkNQxxyoMe6KZlXMr5QPd+3GK0mc="
+  },
+  "org/glassfish/jersey/containers#jersey-container-servlet-core/2.40": {
+   "jar": "sha256-aJkJyNvOvb2R6A954FcRWQTAL37gTf+aq63GYkN2D8A=",
+   "pom": "sha256-wzYb5VbCa2e877WXm/WXCCl2P1j8TVmogKTzLnNpwic="
+  },
+  "org/glassfish/jersey/containers#jersey-container-servlet/2.40": {
+   "jar": "sha256-8W/FTKUcCWSpoYfid9zg+jaylsPQKwK9aFWJtfJ2btI=",
+   "pom": "sha256-UJs6RNnF1skjipWz/5lnDXHFS6XyKvNywy8kEprcXqg="
+  },
+  "org/glassfish/jersey/containers#project/2.40": {
+   "pom": "sha256-aPFwqZEedmjSdwJsGwSfMY/SkID+Ym5Se0SnvJyyqys="
+  },
+  "org/glassfish/jersey/core#jersey-client/2.40": {
+   "jar": "sha256-/eqgPEaooMdhinUWF8a+zN68gILQ6ZLAx5ZbxQ/X2qA=",
+   "pom": "sha256-b/ymQWr/IIwEnbPyD4yWHsC2OafuviJ4ZpWM11qoIUs="
+  },
+  "org/glassfish/jersey/core#jersey-common/2.40": {
+   "jar": "sha256-2sQC5zDhKBa6crH+MQcwHvsKWJymVhclXYa8W3BQgP4=",
+   "pom": "sha256-nMRz8MySHbjbw7eYuZV/XXyoWQtoz10kFhj4AB0z3Lk="
+  },
+  "org/glassfish/jersey/core#jersey-server/2.40": {
+   "jar": "sha256-/6bJPxX5VDFYhB4NfhAsO6m9b4Rdst3gqtNRi8QX0Xg=",
+   "pom": "sha256-gBUXn3r2YPnIA188gqxrc5srxNz7M14kuRRJoJWla28="
+  },
+  "org/glassfish/jersey/inject#jersey-hk2/2.40": {
+   "jar": "sha256-5faawypcguBgP7kLaJv57wuiN7O6Tyu6MVn32MdWs5c=",
+   "pom": "sha256-vXubNRC6JlGxCMIn1chbKjUf7BZ3v0ZQDqOZEfK7pjk="
+  },
+  "org/glassfish/jersey/inject#project/2.40": {
+   "pom": "sha256-nfrVnoiEEXPNRZTSDUq9S6fR01AfFWxLwMmAf5Ez6Fw="
+  },
+  "org/glassfish/jersey/media#jersey-media-sse/2.40": {
+   "jar": "sha256-7JZN+BbDmiOKcRFRERzEGFeKkcLY5/s+gji82IHPu3I=",
+   "pom": "sha256-R0Fc0W0WMOvt5U1JK/+n2mLdqBtg38GTcfoaW7Zix04="
+  },
+  "org/glassfish/jersey/media#project/2.40": {
+   "pom": "sha256-f2aoOw9pzeI+UIc4ql/bTP5DG5Sl8/Yq6xXGAGpmeNU="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  },
+  "org/jacoco#org.jacoco.agent/0.8.11": {
+   "jar": "sha256-0+2F3qeKntVYRqdzjjoMoVxwLGYe5LyMv+Aqi59KmcA=",
+   "pom": "sha256-FuBen0liG4fFPmk1AUDzxG1C2WbGepM730sGOiscj8U="
+  },
+  "org/jacoco#org.jacoco.ant/0.8.11": {
+   "jar": "sha256-gdfriJDZvjCpOWEsKVYDVBBjUpzdA6UyZaunRHS3C3w=",
+   "pom": "sha256-ftED2VnQzue6v7Ewf6bkUbFpb/01JwYVU7VQ3lUgHYU="
+  },
+  "org/jacoco#org.jacoco.build/0.8.11": {
+   "pom": "sha256-W4SxXPLu8+WeuRvCJ4SDMQCwnfmRHjMZAww7xki9iws="
+  },
+  "org/jacoco#org.jacoco.core/0.8.11": {
+   "jar": "sha256-/NGIxohHP8jcwMbKrzVeeziVAiQ1J8M7lZej7Ch5H0c=",
+   "pom": "sha256-u2E18Qo2NJy4SlYA/Yz3P8EpahNbLxStzYPejPJMq7E="
+  },
+  "org/jacoco#org.jacoco.report/0.8.11": {
+   "jar": "sha256-g5MpWuJGgO0QytgzOQcED5KLhxMySRWBylvHhOLLT74=",
+   "pom": "sha256-jjtzR3nV4/1oPsAVQT1S+WGYTFDLkEX9orI7/160I4E="
+  },
+  "org/javassist#javassist/3.27.0-GA": {
+   "jar": "sha256-BzC9sVR6Wj9FjWBADYBAeNgPMpxbXbwkmKTiIN6PcBM=",
+   "pom": "sha256-b9srF2uto+kKs/ifNsUd+cPn3ws2RDfbJKTm+fuboiQ="
+  },
+  "org/javassist#javassist/3.28.0-GA": {
+   "jar": "sha256-V9Cp6ShvgvTqqFESUYaZf4Eb784OIGD/ChWnf1qd2ac=",
+   "pom": "sha256-w2p8E9o6SFKqiBvfnbYLnk0a8UbsKvtTmPltWYP21d0="
+  },
+  "org/javassist#javassist/3.29.2-GA": {
+   "jar": "sha256-qQ3bJRNd+eV+qb1OIk4hlVSSl1j5uumWXyn4HWCjKT8=",
+   "pom": "sha256-Ehu5fA3qc0LXSJInrCe/8J2hJ6TkS14Vy09YyeccbIk="
+  },
+  "org/jetbrains#annotations/13.0": {
+   "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
+   "pom": "sha256-llrrK+3/NpgZvd4b96CzuJuCR91pyIuGN112Fju4w5c="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.6.20": {
+   "jar": "sha256-jaQKJSDTDcsQEhdv6T0k6C0Io+NGw34DQ7D7b2T2vgE=",
+   "pom": "sha256-PgTMk1HVzsQqRcBg+HM/bpTrx+NZExClGOBuiFB4mcg="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.6.10": {
+   "jar": "sha256-Ku3NxrabM731zCNbzqiOfPZgEUa7a83/2zErus174mE=",
+   "pom": "sha256-YSIR/5MPW1LHJP92NBfVqigd1+AyXDs1yNGBIKao300="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.6.10": {
+   "jar": "sha256-FFbYLQOeow2EhbAykB9Su/B+fNvoux+HCK0yqFdMQc4=",
+   "pom": "sha256-Q6ZJ+nN7+zX6SvTm3jPi8IpdGRBNdYLqQNvNK2N5Csw="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/1.6.20": {
+   "jar": "sha256-7rUcK2eyYjP9gdC8T4BE7ISXGIkJBXY87/2Eox4st5k=",
+   "pom": "sha256-oI6D3LDymFCYd94i1SZEZHbdsx6hx3Uw8sgfJNsWb5k="
+  },
+  "org/junit#junit-bom/5.6.3": {
+   "module": "sha256-83owsadq43BY68qsZrkZKkgEVfSo8vKFo1FT0FeMj6o=",
+   "pom": "sha256-7n/i4qbhZ5Ku1Iag0Ka7wjjpuKm3ZHIolOg1z+L0zCA="
+  },
+  "org/junit#junit-bom/5.7.0": {
+   "module": "sha256-Jd5FSzrdZ2VNZpG1PedZO1ApZ7X/VJVHsQTXlh8aUr0=",
+   "pom": "sha256-NfsV+NC+4rWQCiKDJ2I2ZVL5o0nFbO1guhI85Hc4/wA="
+  },
+  "org/junit#junit-bom/5.8.1": {
+   "module": "sha256-a4LLpSoTSxPBmC8M+WIsbUhTcdQLmJJG8xJOOwpbGFQ=",
+   "pom": "sha256-733Ef45KFoZPR3lyjofteFOYGeT7iSdoqdprjvkD+GM="
+  },
+  "org/junit#junit-bom/5.8.2": {
+   "module": "sha256-QM+tmT+nDs3yr3TQxW2hSE7iIJZL6Pkyz+YyvponM/o=",
+   "pom": "sha256-g2Bpyp6O48VuSDdiItopEmPxN70/0W2E/dR+/MPyhuI="
+  },
+  "org/junit#junit-bom/5.9.1": {
+   "module": "sha256-kCbBZWaQ+hRa117Og2dCEaoSrYkwqRsQfC9c3s4vGxw=",
+   "pom": "sha256-sWPBz8j8H9WLRXoA1YbATEbphtdZBOnKVMA6l9ZbSWw="
+  },
+  "org/junit#junit-bom/5.9.2": {
+   "module": "sha256-qxN7pajjLJsGa/kSahx23VYUtyS6XAsCVJdyten0zx8=",
+   "pom": "sha256-LtB9ZYRRMfUzaoZHbJpAVrWdC1i5gVqzZ5uw82819wU="
+  },
+  "org/junit#junit-bom/5.9.3": {
+   "module": "sha256-tAH9JZAeWCpSSqU0PEs54ovFbiSWHBBpvytLv87ka5M=",
+   "pom": "sha256-TQMpzZ5y8kIOXKFXJMv+b/puX9KIg2FRYnEZD9w0Ltc="
+  },
+  "org/mariadb/jdbc#mariadb-java-client/3.1.4": {
+   "jar": "sha256-64i11yfYLiURfitvq87B2vc0YzsKV2RWxzIViEwYmtQ=",
+   "pom": "sha256-zNt9WiXJxef5QoyPg1ClJ1H5T38faRlUwYJ+cdNVTMQ="
+  },
+  "org/mockito#mockito-core/2.28.2": {
+   "pom": "sha256-s78yKr/ubAVJNdaN27eFqQ95NKl6F/zRQKTmrVjlnVM="
+  },
+  "org/mockito#mockito-core/3.3.3": {
+   "jar": "sha256-S+ZIxQRW+6Roa6glAA1ijB2AWjuSJyuprVtpffpDA2s=",
+   "pom": "sha256-z/E7jGMZZKLn2QMV5JFOMayK1EBd/rf5BGRqGNDDlhM="
+  },
+  "org/mockito#mockito-inline/2.28.2": {
+   "jar": "sha256-dDT3GLmIkfMJITyf8LcWVWnhDtG5/oKWNgFqsnrmZEw=",
+   "pom": "sha256-bwNCjNruFgPBZ075ZGBTjYh85RwHE0O1zJz3mCZoGb8="
+  },
+  "org/objenesis#objenesis-parent/2.6": {
+   "pom": "sha256-OCX+yio8F2QAsGPex8awZD4rUla7v9Tgp8EeDdCYO6o="
+  },
+  "org/objenesis#objenesis-parent/3.0.1": {
+   "pom": "sha256-Uzctvo7DgUNwk3qHwDtCtw+stbpXD5n4nBJpN9HYu88="
+  },
+  "org/objenesis#objenesis/2.6": {
+   "pom": "sha256-TBMHkJ3GLfG9kfB1UD+L3vWuRF4TNT8XUq+USL6h0/E="
+  },
+  "org/objenesis#objenesis/3.0.1": {
+   "jar": "sha256-eo/3gLn/SEFdfHBfYAMLCsqmFuf4I8mO7eO2NQjU6YQ=",
+   "pom": "sha256-PcE3flcJdObxgqahaA0yhDNbXVzzqP6nvsGlQ4u9r/g="
+  },
+  "org/ow2#ow2/1.5.1": {
+   "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
+  },
+  "org/ow2/asm#asm-bom/9.6": {
+   "pom": "sha256-ig5fYk/ikwt6jWmVb0OORe9TKZa01kQJthbErvSxrE4="
+  },
+  "org/ow2/asm#asm-commons/9.6": {
+   "jar": "sha256-eu/Q1cCQFwHGn3UT/tp2X7a+M68s56oXxXgfyHZXxRE=",
+   "pom": "sha256-qYrkiVM0uvj/hr1mUWIQ29mgPxpuFeR92oKvz2tT13w="
+  },
+  "org/ow2/asm#asm-tree/9.6": {
+   "jar": "sha256-xD7PF7U5x3fhXae1uGVTs3fi05poPeYoVWfVKDiI5+8=",
+   "pom": "sha256-G8tIHX/Ba5VbtgygfIz6JCS87ni9xAW7oxx9b13C0RM="
+  },
+  "org/ow2/asm#asm/9.6": {
+   "jar": "sha256-PG+sJCTbPUqFO2afTj0dnDxVIjXhmjGWc/iHCDwjA6E=",
+   "pom": "sha256-ku7iS8PIQ+SIHUbB3WUFRx7jFC+s+0ZrQoz+paVsa2A="
+  },
+  "org/postgresql#postgresql/42.5.4": {
+   "jar": "sha256-9I/LC2lZvItHhlf1e6Q8Gsykyt5qvKXxe/m8nDY8tm8=",
+   "pom": "sha256-Dm3UHy8AYgM59rKhwtPTDuh5ugTjrDiytb1kFGyCpYY="
+  },
+  "org/powermock#powermock-api-mockito2/2.0.9": {
+   "jar": "sha256-/jth3/RBY3JMYEZgWRmgzLXyS/DhTy87ikSJTvBPvyw=",
+   "pom": "sha256-vASAcxasdFu7SMc1bhQHY3vKxLvSol83IMLwjlf6Xgc="
+  },
+  "org/powermock#powermock-api-support/2.0.9": {
+   "jar": "sha256-SeTLkEWqv5uygP0hsTQAgAYoD+OU70KORo5d5aHs7uI=",
+   "pom": "sha256-EPMaUjBK/KTIYRkXeaK6oAOubm/YC/3jvuPmknNyO3E="
+  },
+  "org/powermock#powermock-core/2.0.9": {
+   "jar": "sha256-5Rg9Hhl7zWfo+G7rWsxMxLSnqpk+naokn42NaXPwbEk=",
+   "pom": "sha256-INg7E96BSGn0ZuHX5uiMWEEFqKRD7P7WKTCd1NhdLrA="
+  },
+  "org/powermock#powermock-module-junit4-common/2.0.9": {
+   "jar": "sha256-RG+XX/qYlgq26vzLXE0eLLV0f32AzaZTVIoC1YQonoM=",
+   "pom": "sha256-6+kisiwX/QMWoh60Ep44QKY9yq+IQiCmWlSLMyOiYHc="
+  },
+  "org/powermock#powermock-module-junit4/2.0.9": {
+   "jar": "sha256-0OioMYOpqKGP+D4VkqYR+iBsqwg4RmzjZ+PQqFGidOI=",
+   "pom": "sha256-BkFIE8Xrz5HuB5XbnD47U7UitTzlG1Q0j3jlqVIqZuE="
+  },
+  "org/powermock#powermock-reflect/2.0.9": {
+   "jar": "sha256-oTdL02i1K1SyUtUoG5ORNjtYy2Z6Y3UkL9aj9IK8jCM=",
+   "pom": "sha256-MW/2P1sJ4+JApNThyv63/PsnIIzKuq8X/uikVehlSiQ="
+  },
+  "org/reactivestreams#reactive-streams/1.0.4": {
+   "jar": "sha256-91yll3ibPaxY9hhXuawuEDSmj6Zy2zUFWo+0UJ4yXyg=",
+   "pom": "sha256-VLoj2HotQ4VAyZ74eUoIVvxXOiVrSYZ4KDw8Z+8Yrag="
+  },
+  "org/reflections#reflections/0.10.2": {
+   "jar": "sha256-k4otCP5UBQ12ELlE2N3DoJNVcQ2ea+CqyDjbwE6aKCU=",
+   "pom": "sha256-tsqj6301vXVu1usKKoGGi408D29CJE/q5BdgrGYwbYc="
+  },
+  "org/slf4j#jcl-over-slf4j/1.7.36": {
+   "jar": "sha256-q1fKj9IjdywXNl0SH1npTsvwrlnQjAOjy1uBBxwBkZU=",
+   "pom": "sha256-vZYkPX1CGM18x9RcDjD6E0gKGk+R01bt19/pPx/7aOY="
+  },
+  "org/slf4j#slf4j-api/1.7.30": {
+   "pom": "sha256-fgdHdR6bZ+Gdy1IG8E6iLMA9JQxCJCZALq3QNRPywxQ="
+  },
+  "org/slf4j#slf4j-api/2.0.7": {
+   "jar": "sha256-XWKYuToZBcMs2mR4gIrBTC1KR+kVNeU8Qff+64XZRvQ=",
+   "pom": "sha256-LUA8zw4KAtXBqGZ7DiozyN/GA4qyh7lnHdaBwgUmeYE="
+  },
+  "org/slf4j#slf4j-parent/1.7.30": {
+   "pom": "sha256-EWR5VuSKDFv7OsM/bafoPzQQAraFfv0zWlBbaHvjS3U="
+  },
+  "org/slf4j#slf4j-parent/1.7.36": {
+   "pom": "sha256-uziNN/vN083mTDzt4hg4aTIY3EUfBAQMXfNgp47X6BI="
+  },
+  "org/slf4j#slf4j-parent/2.0.7": {
+   "pom": "sha256-wYK7Ns068ck8FgPN/v54iRV9swuotYT0pEU1/NIuRec="
+  },
+  "org/snakeyaml#snakeyaml-engine/2.6": {
+   "jar": "sha256-JlIZmvQMmqLxeCQA0t+79OUiYgjE4F3dQFnD1tnNFQU=",
+   "pom": "sha256-Ep0ib1N1FVWXHyT1DIeJ9kVps4Kj00CU5F/s/G9sF/8="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/yaml#snakeyaml/2.0": {
+   "jar": "sha256-iAydiW5LdKBsVJwVyklkUBZdaQn6FdfmYr7o9qZtevo=",
+   "pom": "sha256-Q8dh+StUnIsI+5kggCU+SfCpg+VE7wZjwfT51o61JhY="
+  },
+  "pl/pragmatists#JUnitParams/1.1.1": {
+   "jar": "sha256-G+GqwW1CTOlA1UB774ZlbcTtWAPJPlY8sWgq4HtZHss=",
+   "pom": "sha256-rgtPWYDWNmgHEacOXCYmnlAvh5Qp2P2aKIdefEdTxR4="
+  },
+  "software/amazon/awssdk#aws-sdk-java-pom/2.18.10": {
+   "pom": "sha256-wCARCxEYrU5/9BuXwMeQi6EuibViRUTS+UFFqseW6l8="
+  },
+  "software/amazon/awssdk#bom/2.18.10": {
+   "pom": "sha256-yrMNWJKRxQ/vTf+6uMMX2ORhR96b5MLy/TmRHidKH6w="
+  },
+  "software/amazon/ion#ion-java/1.0.2": {
+   "jar": "sha256-DRJ7IFofzgq8KjdXoEF0hlG8ZsFc9MBZusWDOyfUcaU=",
+   "pom": "sha256-IKZDxG3mvDDMgfo7njuxaXr6NxaMwYN0VJe3BJabu5I="
+  }
+ }
+}

--- a/pkgs/proxmox-ve/default.nix
+++ b/pkgs/proxmox-ve/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildEnv,
-  linstor-proxmox,
+  linstor-client,
   pve-access-control,
   pve-cluster,
   pve-container,
@@ -24,14 +24,14 @@ buildEnv rec {
     pve-cluster
     pve-container
     pve-firewall
-    pve-ha-manager
-    pve-manager
+    (pve-ha-manager.override { inherit enableLinstor; })
+    (pve-manager.override { inherit enableLinstor; })
     pve-qemu-server
-    pve-storage
+    (pve-storage.override { inherit enableLinstor; })
     termproxy
     vncterm
     wget
-  ] ++ lib.optional enableLinstor linstor-proxmox;
+  ] ++ lib.optionals enableLinstor [ linstor-client ];
 
   meta = with lib; {
     description = "A complete, open-source server management platform for enterprise virtualization";

--- a/pkgs/proxmox-ve/default.nix
+++ b/pkgs/proxmox-ve/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildEnv,
+  linstor-proxmox,
   pve-access-control,
   pve-cluster,
   pve-container,
@@ -12,6 +13,7 @@
   termproxy,
   vncterm,
   wget,
+  enableLinstor ? false,
 }:
 
 buildEnv rec {
@@ -29,7 +31,7 @@ buildEnv rec {
     termproxy
     vncterm
     wget
-  ];
+  ] ++ lib.optional enableLinstor linstor-proxmox;
 
   meta = with lib; {
     description = "A complete, open-source server management platform for enterprise virtualization";

--- a/pkgs/proxmox-ve/default.nix
+++ b/pkgs/proxmox-ve/default.nix
@@ -13,6 +13,7 @@
   termproxy,
   vncterm,
   wget,
+  util-linux,
   enableLinstor ? false,
 }:
 
@@ -31,6 +32,7 @@ buildEnv rec {
     termproxy
     vncterm
     wget
+    util-linux
   ] ++ lib.optionals enableLinstor [ linstor-client ];
 
   meta = with lib; {

--- a/pkgs/pve-ha-manager/default.nix
+++ b/pkgs/pve-ha-manager/default.nix
@@ -10,6 +10,7 @@
   pve-qemu-server,
   pve-storage,
   pve-qemu,
+  enableLinstor ? false,
 }:
 
 let
@@ -18,7 +19,7 @@ let
     pve-firewall
     pve-guest-common
     pve-qemu-server
-    pve-storage
+    (pve-storage.override { inherit enableLinstor; })
   ];
   perlEnv = perl536.withPackages (_: perlDeps);
 in

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -25,6 +25,7 @@
   termproxy,
   shadow,
   wget,
+  util-linux,
 }:
 
 let
@@ -121,6 +122,7 @@ perl536.pkgs.toPerlModule (
               ceph
               gzip
               openssh
+              util-linux
               gnupg
               openvswitch
               pve-qemu

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -9,6 +9,7 @@
   pve-docs,
   pve-ha-manager,
   pve-http-server,
+  enableLinstor ? false,
   ceph,
   gnupg,
   graphviz,
@@ -33,7 +34,7 @@ let
     PodParser
     TemplateToolkit
     proxmox-acme
-    pve-ha-manager
+    (pve-ha-manager.override { inherit enableLinstor; })
     pve-http-server
   ];
 
@@ -125,7 +126,7 @@ perl536.pkgs.toPerlModule (
               pve-qemu
               iproute2
               termproxy
-              pve-ha-manager
+              (pve-ha-manager.override { inherit enableLinstor; })
               shadow
               wget
             ]

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -14,5 +14,6 @@ in
 {
   test-pve-basic = runTest ./basic.nix;
   test-pve-cluster = runTest ./cluster.nix;
+  test-pve-linstor = runTest ./linstor.nix;
   test-pve-vm = runTest (import ./vm.nix { inherit pkgs; });
 }

--- a/tests/linstor.nix
+++ b/tests/linstor.nix
@@ -4,6 +4,7 @@
 
   nodes = {
     pve1 = {
+      boot.kernelModules = [ "drbd" ];
       services.proxmox-ve = {
         enable = true;
         linstor.enable = true;
@@ -11,6 +12,7 @@
       virtualisation.memorySize = 2048;
     };
     pve2 = {
+      boot.kernelModules = [ "drbd" ];
       services.proxmox-ve = {
         enable = true;
         linstor.enable = true;

--- a/tests/linstor.nix
+++ b/tests/linstor.nix
@@ -4,11 +4,18 @@
 
   nodes = {
     pve1 = {
-      services.proxmox-ve = {
-        enable = true;
-        linstor.enable = true;
+      services = {
+        proxmox-ve = {
+          enable = true;
+          linstor.enable = true;
+        };
+        lvm.enable = true;
+        lvm.dmeventd.enable = true;
       };
-      virtualisation.memorySize = 2048;
+      virtualisation = {
+        emptyDiskImages = [ 4096 ];
+        memorySize = 2048;
+      };
     };
     pve2 = {
       services.proxmox-ve = {
@@ -26,8 +33,15 @@
     assert "running" in pve1.succeed("pveproxy status")
     assert "Proxmox" in pve1.succeed("curl -k https://localhost:8006")
 
-    pve1.wait_for_unit("linstor-controller.service")
+    pve1.wait_for_unit("multi-user.target")
     pve2.wait_for_unit("multi-user.target")
+
+    pve1.succeed("linstor node create pve1 192.168.0.1")
+    pve1.succeed("vgcreate linstor_vg /dev/vdb")
+    pve1.succeed("lvcreate -l 80%FREE -T linstor_vg/thinpool")
+    pve1.succeed("linstor storage-pool create lvmthin pve1 pve-storage linstor_vg/thinpool")
+    pve1.succeed("linstor resource-group create pve-rg --storage-pool=pve-storage --place-count=1")
+    pve1.succeed("linstor volume-group create pve-rg")
 
     storageCfg = """
     drbd: linstor_storage
@@ -39,6 +53,8 @@
     pve1.succeed("cat /etc/pve/storage.cfg")
     assert "9.2" in pve1.succeed("modinfo drbd")
     assert "drbd" in pve1.succeed("cat /proc/modules")
+
+    pve1.succeed("systemctl restart pve-cluster pvedaemon pvestatd pveproxy")
 
     pve1.succeed("linstor node create pve1 192.168.0.1")
   '';

--- a/tests/linstor.nix
+++ b/tests/linstor.nix
@@ -4,7 +4,6 @@
 
   nodes = {
     pve1 = {
-      boot.kernelModules = [ "drbd" ];
       services.proxmox-ve = {
         enable = true;
         linstor.enable = true;
@@ -40,6 +39,7 @@
     pve1.succeed(f"echo \"{storageCfg}\" >> /etc/pve/storage.cfg")
     pve1.succeed("cat /etc/pve/storage.cfg")
     assert "9.2" in pve1.succeed("modinfo drbd")
+    assert "drbd" in pve1.succeed("cat /proc/modules")
 
     pve1.succeed("linstor node create pve1 192.168.0.1")
   '';

--- a/tests/linstor.nix
+++ b/tests/linstor.nix
@@ -11,7 +11,6 @@
       virtualisation.memorySize = 2048;
     };
     pve2 = {
-      boot.kernelModules = [ "drbd" ];
       services.proxmox-ve = {
         enable = true;
         linstor.enable = true;

--- a/tests/linstor.nix
+++ b/tests/linstor.nix
@@ -36,7 +36,10 @@
     pve1.wait_for_unit("multi-user.target")
     pve2.wait_for_unit("multi-user.target")
 
-    pve1.succeed("linstor node create pve1 192.168.0.1")
+    pve1.wait_for_unit("linstor-satellite.service")
+    pve1.wait_for_unit("linstor-controller.service")
+
+    pve1.succeed("linstor node create pve1 192.168.0.1 >&2")
     pve1.succeed("vgcreate linstor_vg /dev/vdb")
     pve1.succeed("lvcreate -l 80%FREE -T linstor_vg/thinpool")
     pve1.succeed("linstor storage-pool create lvmthin pve1 pve-storage linstor_vg/thinpool")

--- a/tests/linstor.nix
+++ b/tests/linstor.nix
@@ -1,0 +1,30 @@
+{
+
+  name = "pve-linstor";
+
+  nodes = {
+    pve1 = {
+      services.proxmox-ve = {
+        enable = true;
+        linstor.enable = true;
+      };
+    };
+    pve2 = {
+      services.proxmox-ve = {
+        enable = true;
+        linstor.enable = true;
+      };
+    };
+  };
+
+  testScript = ''
+    pve1.start()
+    pve2.start()
+    pve1.wait_for_unit("pveproxy.service")
+    assert "running" in pve1.succeed("pveproxy status")
+    assert "Proxmox" in pve1.succeed("curl -k https://localhost:8006")
+    pve1.succeed("pvecm create mycluster")
+    pve1.wait_for_unit("corosync.service")
+    pve2.wait_for_unit("multi-user.target")
+  '';
+}

--- a/tests/linstor.nix
+++ b/tests/linstor.nix
@@ -8,12 +8,14 @@
         enable = true;
         linstor.enable = true;
       };
+      virtualisation.memorySize = 2048;
     };
     pve2 = {
       services.proxmox-ve = {
         enable = true;
         linstor.enable = true;
       };
+      virtualisation.memorySize = 2048;
     };
   };
 
@@ -21,6 +23,7 @@
     pve1.start()
     pve2.start()
     pve1.wait_for_unit("pveproxy.service")
+    pve1.wait_for_unit("linstor-controller.service")
     assert "running" in pve1.succeed("pveproxy status")
     assert "Proxmox" in pve1.succeed("curl -k https://localhost:8006")
     pve1.succeed("pvecm create mycluster")


### PR DESCRIPTION
This adds:
- the Linstor server
- the Linstor client
- the Linstor Proxmox plugin
- options to enable [Linstor](https://linbit.com/blog/linstor-setup-proxmox-ve-volumes/) on Proxmox
- a NixOS test to check that Linstor works correctly.