### PR TITLE
Add option to declaratively configure visible bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ environment.persistence."/persistent".directories = [
 
 To get internet in your VMs, you need to add a network device to the VM, connected to a bridge. To get this working, follow this 2 steps:
 
-1. Create the bridge in `System->Network->Create->Linux Bridge`. This operation has no effect on your system and is just a quirk for Proxmox to know the existence of your bridge.
+1. Set the list of bridges in `services.proxmox-ve.bridges` option. This is the list of bridges that will be visible in Proxmox web interface. Note that this option doesn't affect your OS level network config in any way.
 2. Configure your networking through NixOS configuration so that the bridge you created in the Proxmox web interface actually exists!
 
 ### Example NixOS networking configurations
@@ -128,6 +128,10 @@ Any kind of advanced networking configuration is possible through the usual NixO
 #### With `systemd-networkd`
 
 ```nix
+# Make vmbr0 bridge visible in Proxmox web interface
+services.proxmox-ve.bridges = [ "vmbr0" ];
+
+# Actually set up the vmbr0 bridge
 systemd.network.networks."10-lan" = {
     matchConfig.Name = [ "ens18" ];
     networkConfig = {
@@ -155,6 +159,10 @@ systemd.network.networks."10-lan-bridge" = {
 ### With scripted networking
 
 ```nix
+# Make vmbr0 bridge visible in Proxmox web interface
+services.proxmox-ve.bridges = [ "vmbr0" ];
+
+# Actually set up the vmbr0 bridge
 networking.bridges.vmbr0.interfaces = [ "ens18" ];
 networking.interfaces.vmbr0.useDHCP = lib.mkDefault true;
 ```

--- a/modules/proxmox-ve/bridges.nix
+++ b/modules/proxmox-ve/bridges.nix
@@ -1,0 +1,26 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.proxmox-ve.bridges;
+in
+{
+  options.services.proxmox-ve.bridges = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = [ ];
+    description = "List of Linux or OVS bridges visible in Proxmox web interface. This option has no effect on OS level network config.";
+  };
+
+  config = lib.mkIf (builtins.length cfg > 0) {
+    environment.etc."network/interfaces" = {
+      mode = "0644";
+      text = lib.concatMapStringsSep "\n" (br: ''
+        auto ${br}
+        iface ${br} inet static
+          bridge_ports none
+      '') cfg;
+    };
+  };
+}

--- a/modules/proxmox-ve/default.nix
+++ b/modules/proxmox-ve/default.nix
@@ -18,6 +18,7 @@ in
 
   imports = [
     ./ceph.nix
+    ./bridges.nix
     ./cluster.nix
     # ./firewall.nix
     # ./ha-manager.nix


### PR DESCRIPTION
Add an option to declaratively set the list of bridges visible in Proxmox web interface, so users do not have to manually add the bridge on web interface.

This also helps if `/etc/network/interfaces` is not persisted across reboots, such as in an impermanence situation.