### PR TITLE
pve-edk2-firmware: init

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -43,6 +43,7 @@ let
     pve-common = callPackage ./pve-common { };
     pve-container = callPackage ./pve-container { };
     pve-docs = callPackage ./pve-docs { };
+    pve-edk2-firmware = callPackage ./pve-edk2-firmware { };
     pve-firewall = callPackage ./pve-firewall { };
     pve-guest-common = callPackage ./pve-guest-common { };
     pve-ha-manager = callPackage ./pve-ha-manager { };

--- a/pkgs/pve-edk2-firmware/default.nix
+++ b/pkgs/pve-edk2-firmware/default.nix
@@ -87,6 +87,13 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  passthru.updateScript = [
+    ../update.py
+    pname
+    "--url"
+    src.url
+  ];
+
   meta = {
     description = "edk2 based UEFI firmware modules for virtual machines";
     homepage = "git://git.proxmox.com/git/${pname}.git";

--- a/pkgs/pve-edk2-firmware/default.nix
+++ b/pkgs/pve-edk2-firmware/default.nix
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
 
   buildInputs = [ ];
 
-  hardeningDisable = [ "all" ];
+  hardeningDisable = [ "format" "fortify" "trivialautovarinit" ];
 
   nativeBuildInputs = with pkgs; [
     dpkg fakeroot qemu
@@ -45,6 +45,10 @@ stdenvNoCC.mkDerivation rec {
     substituteInPlace ./debian/rules \
       --replace-warn 'PYTHONPATH=$(CURDIR)/debian/python' 'PYTHONPATH=$(CURDIR)/debian/python:${pythonPath}'
 
+    # Skip dh calls because we don't need debhelper
+    substituteInPlace ./debian/rules \
+      --replace-warn 'dh $@' ': dh $@'
+
     # Patch cross compiler paths
     substituteInPlace ./debian/rules ./**/CMakeLists.txt \
       --replace-warn 'aarch64-linux-gnu-' 'aarch64-unknown-linux-gnu-'
@@ -64,7 +68,7 @@ stdenvNoCC.mkDerivation rec {
     # Apply patches using dpkg 
     dpkg-source -b .
 
-    make -f debian/rules build-qemu-efi-aarch64 build-ovmf build-ovmf32 build-qemu-efi-riscv64
+    make -f debian/rules override_dh_auto_build
   '';
 
   installPhase = ''

--- a/pkgs/pve-edk2-firmware/default.nix
+++ b/pkgs/pve-edk2-firmware/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
 
       # Patch paths in produced .install scripts
       substituteInPlace ./debian/*.install \
-        --replace-warn '/usr/share/pve-edk2-firmware' "$out"
+        --replace-warn '/usr/share/pve-edk2-firmware' "$out/usr/share/pve-edk2-firmware"
     '';
 
   buildPhase = 

--- a/pkgs/pve-edk2-firmware/default.nix
+++ b/pkgs/pve-edk2-firmware/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  python3,
+  pkgs, 
+  stdenv, 
+  fetchgit,
+  ... 
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pve-edk2-firmware";
+  version = "4.2023.08-4";
+
+  src = fetchgit {
+    url = "git://git.proxmox.com/git/${pname}.git";
+    rev = "17443032f78eaf9ae276f8df9d10c64beec2e048";
+    sha256 = "sha256-19frOpnL8xLWIDw58u1zcICU9Qefp936LteyfnSIMCw=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ ];
+
+  hardeningDisable = [ "format" ];
+
+  nativeBuildInputs = with pkgs; [
+    dpkg fakeroot qemu
+    bc dosfstools acpica-tools mtools nasm libuuid
+    qemu-utils libisoburn python3
+  ];
+
+  prePatch = 
+  let
+    pythonPath = python3.pkgs.makePythonPath (with python3.pkgs; [ pexpect ]);
+  in
+  ''
+    patchShebangs .
+    substituteInPlace ./debian/rules \
+      --replace-warn /bin/bash ${pkgs.bash}/bin/bash
+    substituteInPlace ./Makefile ./debian/rules \
+      --replace-warn /usr/share/dpkg ${pkgs.dpkg}/share/dpkg
+    substituteInPlace ./debian/rules \
+      --replace-warn 'PYTHONPATH=$(CURDIR)/debian/python' 'PYTHONPATH=$(CURDIR)/debian/python:${pythonPath}'
+  '';
+
+  buildPhase = 
+  let
+    mainVersion = builtins.head (lib.splitString "-" version);
+  in
+  ''
+    # Set up build directory (src)
+    make ${pname}_${mainVersion}.orig.tar.gz
+    pushd ${pname}-${mainVersion}
+
+    # Apply patches using dpkg 
+    dpkg-source -b .
+
+    make -f debian/rules build-ovmf
+    make -f debian/rules build-ovmf32
+  '';
+
+  installPhase = ''
+    mkdir -p $out/legacy
+    cp -r ./debian/ovmf32-install/. $out/
+    cp -r ./debian/ovmf-install/. $out/
+    cp -r ./debian/legacy-2M-builds/. $out/legacy/
+    cp ./debian/PkKek-1-snakeoil.key $out/
+    cp ./debian/PkKek-1-snakeoil.pem $out/
+  '';
+
+  meta = {
+    description = "edk2 based UEFI firmware modules for virtual machines";
+    homepage = "git://git.proxmox.com/git/${pname}.git";
+    maintainers = with lib.maintainers; [ ];
+  };
+ }

--- a/pkgs/pve-qemu-server/default.nix
+++ b/pkgs/pve-qemu-server/default.nix
@@ -7,6 +7,7 @@
   json_c,
   pkg-config,
   proxmox-backup-client,
+  pve-edk2-firmware,
   pve-qemu,
   util-linux,
   uuid,
@@ -108,7 +109,7 @@ perl536.pkgs.toPerlModule (
         -e "s|qemu-kvm|${pve-qemu}/bin/qemu-kvm|" \
         -e "s|qemu-system|${pve-qemu}/bin/qemu-system|" \
         -e "s|/var/lib/qemu-server|$out/lib/qemu-server|" \
-
+        -e "s|/usr/share/pve-edk2-firmware|${pve-edk2-firmware}/usr/share/pve-edk2-firmware|" \
         #-e "s|/usr/bin/proxmox-backup-client|${proxmox-backup-client}/bin/proxmox-backup-client|" \
         #-e "s|/usr/sbin/qm|$out/bin/qm|" \
         #-e "s|/usr/bin/qemu|${pve-qemu}/bin/qemu|" \

--- a/tests/vm.nix
+++ b/tests/vm.nix
@@ -16,9 +16,25 @@
     assert "running" in machine.succeed("pveproxy status")
     machine.succeed("mkdir -p /var/lib/vz/template/iso/")
     machine.succeed("cp ${pkgs.nixos-proxmox-ve-iso}/iso/*.iso /var/lib/vz/template/iso/nixos-proxmox-ve.iso")
+
+    # Seabios VM creation
     machine.succeed("qm create 100 --kvm 0 --bios seabios -cdrom local:iso/nixos-proxmox-ve.iso")
     machine.succeed("qm start 100")
+    machine.succeed("qm stop 100 --timeout 0")
+
+    # Legacy ovmf vm creation
     machine.succeed("qm create 101 --kvm 0 --bios ovmf -cdrom local:iso/nixos-proxmox-ve.iso")
     machine.succeed("qm start 101")
+    machine.succeed("qm stop 101 --timeout 0")
+
+    # UEFI ovmf vm creation
+    machine.succeed("qm create 102 --kvm 0 --bios ovmf --efidisk0 local:4,efitype=4m -cdrom local:iso/nixos-proxmox-ve.iso")
+    machine.succeed("qm start 102")
+    machine.succeed("qm stop 102 --timeout 0")
+
+    # UEFI ovmf vm creation with secure boot
+    machine.succeed("qm create 103 --kvm 0 --bios ovmf --efidisk0 local:4,efitype=4m,pre-enrolled-keys=1 -cdrom local:iso/nixos-proxmox-ve.iso")
+    machine.succeed("qm start 103")
+    machine.succeed("qm stop 103 --timeout 0")
   '';
 }

--- a/tests/vm.nix
+++ b/tests/vm.nix
@@ -16,7 +16,9 @@
     assert "running" in machine.succeed("pveproxy status")
     machine.succeed("mkdir -p /var/lib/vz/template/iso/")
     machine.succeed("cp ${pkgs.nixos-proxmox-ve-iso}/iso/*.iso /var/lib/vz/template/iso/nixos-proxmox-ve.iso")
-    machine.succeed("qm create 100 --kvm 0 -cdrom local:iso/nixos-proxmox-ve.iso")
+    machine.succeed("qm create 100 --kvm 0 --bios seabios -cdrom local:iso/nixos-proxmox-ve.iso")
     machine.succeed("qm start 100")
+    machine.succeed("qm create 101 --kvm 0 --bios ovmf -cdrom local:iso/nixos-proxmox-ve.iso")
+    machine.succeed("qm start 101")
   '';
 }


### PR DESCRIPTION
This is another attempt of fixing UEFI by adding edk2 firmware (kudos to #47), which fix #14, #29 and #46. Instead of using prebuilt binaries, this PR builds the OVMF firmware from source.

All supported firmware architectures are built:

* IA32
* X64
* AArch64
* Riscv64

Compiling has been tested on both `x86_64-linux` and `aarch64-linux` builders.

Added vm creation unit test to cover following 4 scenarios:

* SeaBIOS (Legacy)
* OVMF (Legacy)
* OVMF (UEFI)
* OVMF (UEFI + Secure Boot)

Tested to be working:

![image](https://github.com/user-attachments/assets/16f120ad-c6dd-4902-8d6e-e5d53c784831)

---

One trade-off was made in this PR: I used `dpkg-source` for applying patches from Proxmox instead of Nix's native `patches` definition (e.g. the way [pve-qemu](https://github.com/SaumonNet/proxmox-nixos/blob/53f9cd6ad81f1bf36b257470d82e77e0629578c8/pkgs/pve-qemu/default.nix#L19) apply the patches), so that I could reuse the existing generic `update.py` script. 
Please let me know your thoughts on this. I can also write a custom bash script as updater if the latter way is preferred.
