### PR TITLE
pve-manager: add btrfs and zfs tools to service env paths

### DIFF
--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -21,6 +21,7 @@ lib.mkIf cfg.enable {
         "corosync.service"
         "pve-cluster.service"
       ];
+      path = [ pkgs.zfs ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/pvedaemon start";
         ExecStop = "${cfg.package}/bin/pvedaemon stop";
@@ -141,6 +142,7 @@ lib.mkIf cfg.enable {
       description = "PVE Status Daemon";
       wants = [ "pve-cluster.service" ];
       after = [ "pve-cluster.service" ];
+      path = [ pkgs.zfs ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/pvestatd start";
         ExecStop = "${cfg.package}/bin/pvestatd stop";

--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -21,7 +21,7 @@ lib.mkIf cfg.enable {
         "corosync.service"
         "pve-cluster.service"
       ];
-      path = [ pkgs.zfs ];
+      path = with pkgs; [ btrfs-progs zfs ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/pvedaemon start";
         ExecStop = "${cfg.package}/bin/pvedaemon stop";
@@ -142,7 +142,7 @@ lib.mkIf cfg.enable {
       description = "PVE Status Daemon";
       wants = [ "pve-cluster.service" ];
       after = [ "pve-cluster.service" ];
-      path = [ pkgs.zfs ];
+      path = with pkgs; [ btrfs-progs zfs ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/pvestatd start";
         ExecStop = "${cfg.package}/bin/pvestatd stop";


### PR DESCRIPTION
This change adds `pkgs.btrfs-progs` and `pkgs.zfs` to `PATH` for two following systemd services to fix #28, and fix #63:

* `pvedaemon.service`
* `pvestatd.service`

This will make showing and creating btrfs / zfs storages work properly.

---

Fixed by adding binaries to path instead of patching the original perl scripts because the latter does not seem maintainable.

For example: https://github.com/proxmox/pve-storage/blob/ec5395868f5f24c0dcddd3f7e572db337160706e/src/PVE/Storage.pm#L1415, the command is composed as array and passed to `open3()` function. It is not very maintainable for me to patch the scripts as it is hard to distinguish commands and non-commands for `zfs`.  

---

![image-zfs](https://github.com/user-attachments/assets/27455f69-7256-4559-b202-70fd2ee7ac53)
![image-btrfs](https://github.com/user-attachments/assets/d6c12f2b-2df2-4644-8d89-54b9339e9a43)