### PR TITLE
pve-novnc: support update script

### DIFF
--- a/pkgs/pve-novnc/default.nix
+++ b/pkgs/pve-novnc/default.nix
@@ -1,24 +1,32 @@
 {
+  lib,
   novnc,
   esbuild,
   fetchgit,
 }:
 
 novnc.overrideAttrs (old: rec {
-  src_patches = fetchgit {
+  pname = "pve-novnc";
+  version = "1.4.0-4";
+
+  src = fetchgit {
     url = "git://git.proxmox.com/git/novnc-pve.git";
+    rev = "e410ca0eea1d2ab9d3bf93db8e5e1c44cd8229fb";
     hash = "sha256-BQm4hDC7b+YaFipVonzcwVG/4JswkMSFZEpVkCdfrjM=";
+    fetchSubmodules = true;
   };
 
   patches =
     let
-      series = builtins.readFile "${src_patches}/debian/patches/series";
+      series = builtins.readFile "${src}/debian/patches/series";
       patchList = builtins.filter (patch: builtins.isString patch && patch != "") (
         builtins.split "\n" series
       );
-      patchPathsList = map (patch: "${src_patches}/debian/patches/${patch}") patchList;
+      patchPathsList = map (patch: "${src}/debian/patches/${patch}") patchList;
     in
     old.patches ++ patchPathsList;
+
+  sourceRoot = "${src.name}/novnc";
 
   buildInputs = [ esbuild ];
 
@@ -31,4 +39,15 @@ novnc.overrideAttrs (old: rec {
       cp app.js $out/share/webapps/novnc/
       mv $out/share/webapps/novnc/{vnc.html,index.html.tpl}
     '';
+
+  passthru.updateScript = [
+    ../update.py
+    pname
+    "--url"
+    src.url
+    "--version-prefix"
+    (lib.versions.majorMinor old.version)
+  ];
+
+  meta.position = builtins.dirOf ./.;
 })

--- a/pkgs/update.py
+++ b/pkgs/update.py
@@ -23,6 +23,8 @@ def main():
     parser.add_argument('pkg_name', help='Name of the package to update')
     parser.add_argument('--url', help='URL of the Git source', default=None)
     parser.add_argument('--version', help='Specify the version to update to')
+    parser.add_argument('--version-prefix', default=None,
+                        help='Specify the prefix of targeted update version')
     parser.add_argument('--prefix', default='bump version to',
                         help='Prefix for the commit message')
     parser.add_argument('--root', default='.',
@@ -53,8 +55,10 @@ def main():
         version = args.version
     else:
         print('Finding latest version')
+        grep_prefix = f'{args.prefix} {args.version_prefix}' if args.version_prefix else args.prefix
+            
         log_output = run_command(
-            f'git log --grep="{args.prefix}" -n 1 --pretty=format:"%s"')
+            f'git log --grep="{grep_prefix}" -n 1 --pretty=format:"%s"')
         version_match = re.search(f'{re.escape(args.prefix)} (.*)', log_output)
         version = version_match.group(1) if version_match else None
 


### PR DESCRIPTION
This PR attempts to make `pve-novnc` support the existing update script by:

- Using Proxmox's git source and clone the original novnc as submodule
- Specify `sourceRoot` to `./novnc` to make existing build scripts compatible
- Add a `--version-prefix` parameter to `update.py` so we can limit the major.minor version of update target version. This is done to make sure build commands in nixpkgs are compatible for automatically updated versions.

Welcome any discussions on this method of working-around auto updates. If this is an acceptable solution for similar packages that needs both `src` and `src_patches` (e.g. `pve-qemu`), I plan to invest some time in updating these packages using the same pattern of this PR.

Tested by manually setting it to an older commit, then:

```bash
nix-shell tasks/update.nix --argstr package pve-novnc
```
