### PR TITLE
Fix failed to add cloud-init driver

### DIFF
--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -21,7 +21,7 @@ lib.mkIf cfg.enable {
         "corosync.service"
         "pve-cluster.service"
       ];
-      path = with pkgs; [ btrfs-progs zfs ];
+      path = with pkgs; [ btrfs-progs zfs bashInteractive cdrkit ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/pvedaemon start";
         ExecStop = "${cfg.package}/bin/pvedaemon stop";


### PR DESCRIPTION
This PR will fix failure to create vm using cloud-init driver

The `pvedaemon` will run follwing command to create cloud init disk

```bash
bash -c set -o pipefail && genisoimage -quiet -iso-level 3 -R -V cidata /run/pve/cloudinit/100/ | qemu-img dd -n -f raw -O qcow2 'isize=0' 'osize=4194304' 'of=/var/lib/vz/images/100/vm-100-cloudinit.qcow2' 
```

<img width="847" alt="Error Message" src="https://github.com/user-attachments/assets/80088525-9670-4ffa-9a3a-e6cd5e3ce8b2">
