### PR TITLE
feat: add PVE spiceproxy

### DIFF
--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -169,7 +169,27 @@ lib.mkIf cfg.enable {
     #   };
     # };
 
-    # spiceproxy = { };
+    spiceproxy = {
+      description = "PVE SPICE Proxy Server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "pveproxy.service" ];
+      wants = [ "pveproxy.service" ];
+      serviceConfig = {
+        ExecStartPre = [
+          "${pkgs.coreutils}/bin/touch /var/lock/spiceproxy.lck"
+          "${pkgs.coreutils}/bin/chown www-data:www-data /var/lock/spiceproxy.lck"
+        ];
+        ExecStart = "${pkgs.proxmox-ve}/bin/spiceproxy start";
+        ExecStop = [
+          "${pkgs.coreutils}/bin/rm -f /var/lock/spiceproxy.lck"
+          "${pkgs.proxmox-ve}/bin/spiceproxy stop"
+        ];
+        ExecReload = "${pkgs.proxmox-ve}/bin/spiceproxy restart";
+        PIDFile = "/run/pveproxy/spiceproxy.pid"; # the code puts it here, not in /run/spiceproxy/
+        Type = "forking";
+        Restart = "on-failure";
+      };
+    };
   };
 
   systemd.tmpfiles.rules = [ "d /var/log/pveproxy 0755 www-data www-data -" ];


### PR DESCRIPTION
I enabled PVE spiceproxy and tested it out with Display>Graphics Card: **SPICE (qxl)** & **VirtIO-GPU (virtio)**.   They both are working fine using virt-viewer when you click "Console: SPICE" in the web UI. 

On my system, I wasn't able to use VirGL GPU (virtio-gl). It can't seem to find the libraries (which is a different issue). I might be missing something, or paths are incorrect. More info on that [here](https://github.com/roperscrossroads/nixos-config/tree/main). 
