### PR TITLE
Add TPM support

### DIFF
--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -21,7 +21,7 @@ lib.mkIf cfg.enable {
         "corosync.service"
         "pve-cluster.service"
       ];
-      path = with pkgs; [ btrfs-progs zfs bashInteractive cdrkit ];
+      path = with pkgs; [ btrfs-progs zfs bashInteractive cdrkit swtpm ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/pvedaemon start";
         ExecStop = "${cfg.package}/bin/pvedaemon stop";
@@ -83,6 +83,7 @@ lib.mkIf cfg.enable {
         "pve-ha-crm.service"
         "pve-ha-lrm.service"
       ];
+      path = with pkgs; [ swtpm ];
       unitConfig = {
         RefuseManualStart = true;
         RefuseManualStop = true;

--- a/pkgs/pve-qemu-server/default.nix
+++ b/pkgs/pve-qemu-server/default.nix
@@ -15,6 +15,7 @@
   termreadline,
   socat,
   vncterm,
+  swtpm,
 }:
 
 let
@@ -74,7 +75,6 @@ perl538.pkgs.toPerlModule (
 
       # Fix QEMU version check
       sed -i PVE/QemuServer.pm -e "s/\[,\\\s\]//"
-
     '';
 
     buildInputs = [
@@ -110,6 +110,7 @@ perl538.pkgs.toPerlModule (
         -e "s|qemu-system|${pve-qemu}/bin/qemu-system|" \
         -e "s|/var/lib/qemu-server|$out/lib/qemu-server|" \
         -e "s|/usr/share/pve-edk2-firmware|${pve-edk2-firmware}/usr/share/pve-edk2-firmware|" \
+        -e 's|/etc/swtpm_setup.conf|${swtpm}/etc/swtpm_setup.conf|' \
         #-e "s|/usr/bin/proxmox-backup-client|${proxmox-backup-client}/bin/proxmox-backup-client|" \
         #-e "s|/usr/sbin/qm|$out/bin/qm|" \
         #-e "s|/usr/bin/qemu|${pve-qemu}/bin/qemu|" \


### PR DESCRIPTION
`pvedaemon` call `swtpm_setup` to setup TPM support for vm. 

This patch add swtpm support and Windows 11 vm is require TPM.
