### PR TITLE
pve-storage: add XML::LibXML dep

### DIFF
--- a/pkgs/pve-storage/default.nix
+++ b/pkgs/pve-storage/default.nix
@@ -34,6 +34,7 @@ let
     with perl538.pkgs;
     [
       Filechdir
+      XMLLibXML
       posixstrptime
       pve-cluster
       pve-rados2


### PR DESCRIPTION
Without this dep, I get an error migrating a VM to my NixOS-based host:

```
2025-01-01 15:26:48 starting migration of VM 110 to node 'apollo' (10.0.2.11)
2025-01-01 15:26:48 found local disk 'local-zfs:vm-110-disk-0' (attached)
2025-01-01 15:26:48 found generated disk 'local-zfs:vm-110-disk-2' (in current VM config)
2025-01-01 15:26:48 copying local disk images
2025-01-01 15:26:49 full send of rpool/data/vm-110-disk-2@__migration__ estimated size is 45.0K
2025-01-01 15:26:49 total estimated size is 45.0K
2025-01-01 15:26:49 TIME        SENT   SNAPSHOT rpool/data/vm-110-disk-2@__migration__
2025-01-01 15:26:49 Can't locate XML/LibXML.pm in @INC (you may need to install the XML::LibXML module) (@INC entries checked: /nix/store/dvhhasabjbj305mj0czljrm235k38yvx-pve-storage-8.3.2/lib/perl5/site_perl/5.38.2 /nix/store/dvhhasabjbj305mj0czljrm235k38yvx-pve-storage-8.3.2/lib/perl5/site_perl/5.38.2 /nix/store/szwjmlmyqmci3251xs8rq7q569ijp1cj-perl-5.38.2-env/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi /nix/store/szwjmlmyqmci3251xs8rq7q569ijp1cj-perl-5.38.2-env/lib/perl5/site_perl/5.38.2 /nix/store/szwjmlmyqmci3251xs8rq7q569ijp1cj-perl-5.38.2-env/lib/perl5/site_perl /nix/store/n0ry14wp6gvn5vglkdxmgipkw9z4pjf6-perl-5.38.2/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi /nix/store/n0ry14wp6gvn5vglkdxmgipkw9z4pjf6-perl-5.38.2/lib/perl5/site_perl/5.38.2 /nix/store/n0ry14wp6gvn5vglkdxmgipkw9z4pjf6-perl-5.38.2/lib/perl5/5.38.2/x86_64-linux-thread-multi /nix/store/n0ry14wp6gvn5vglkdxmgipkw9z4pjf6-perl-5.38.2/lib/perl5/5.38.2) at /nix/store/dvhhasabjbj305mj0czljrm235k38yvx-pve-storage-8.3.2/lib/perl5/site_perl/5.38.2/PVE/GuestImport/OVF.pm line 8, <DATA> line 960.
2025-01-01 15:26:49 BEGIN failed--compilation aborted at /nix/store/dvhhasabjbj305mj0czljrm235k38yvx-pve-storage-8.3.2/lib/perl5/site_perl/5.38.2/PVE/GuestImport/OVF.pm line 8, <DATA> line 960.
2025-01-01 15:26:49 Compilation failed in require at /nix/store/dvhhasabjbj305mj0czljrm235k38yvx-pve-storage-8.3.2/lib/perl5/site_perl/5.38.2/PVE/Storage/DirPlugin.pm line 13, <DATA> line 960.
2025-01-01 15:26:49 BEGIN failed--compilation aborted at /nix/store/dvhhasabjbj305mj0czljrm235k38yvx-pve-storage-8.3.2/lib/perl5/site_perl/5.38.2/PVE/Storage/DirPlugin.pm line 13, <DATA> line 960.
2025-01-01 15:26:49 Compilation failed in require at /nix/store/dvhhasabjbj305mj0czljrm235k38yvx-pve-storage-8.3.2/lib/perl5/site_perl/5.38.2/PVE/Storage.pm line 28, <DATA> line 960.
2025-01-01 15:26:49 BEGIN failed--compilation aborted at /nix/store/dvhhasabjbj305mj0czljrm235k38yvx-pve-storage-8.3.2/lib/perl5/site_perl/5.38.2/PVE/Storage.pm line 28, <DATA> line 960.
2025-01-01 15:26:49 Compilation failed in require at /nix/store/dvhhasabjbj305mj0czljrm235k38yvx-pve-storage-8.3.2/lib/perl5/site_perl/5.38.2/PVE/CLI/pvesm.pm line 19, <DATA> line 960.
2025-01-01 15:26:49 BEGIN failed--compilation aborted at /nix/store/dvhhasabjbj305mj0czljrm235k38yvx-pve-storage-8.3.2/lib/perl5/site_perl/5.38.2/PVE/CLI/pvesm.pm line 19, <DATA> line 960.
2025-01-01 15:26:49 Compilation failed in require at /run/current-system/sw/bin/pvesm line 6, <DATA> line 960.
2025-01-01 15:26:49 BEGIN failed--compilation aborted at /run/current-system/sw/bin/pvesm line 6, <DATA> line 960.
send/receive failed, cleaning up snapshot(s)..
2025-01-01 15:26:49 ERROR: storage migration for 'local-zfs:vm-110-disk-2' to storage 'local-zfs' failed - command 'set -o pipefail && pvesm export local-zfs:vm-110-disk-2 zfs - -with-snapshots 0 -snapshot __migration__ | /usr/bin/ssh -e none -o 'BatchMode=yes' -o 'HostKeyAlias=apollo' -o 'UserKnownHostsFile=/etc/pve/nodes/apollo/ssh_known_hosts' -o 'GlobalKnownHostsFile=none' root@10.0.2.11 -- pvesm import local-zfs:vm-110-disk-2 zfs - -with-snapshots 0 -snapshot __migration__ -delete-snapshot __migration__ -allow-rename 1' failed: exit code 2
2025-01-01 15:26:49 aborting phase 1 - cleanup resources
2025-01-01 15:26:49 ERROR: migration aborted (duration 00:00:01): storage migration for 'local-zfs:vm-110-disk-2' to storage 'local-zfs' failed - command 'set -o pipefail && pvesm export local-zfs:vm-110-disk-2 zfs - -with-snapshots 0 -snapshot __migration__ | /usr/bin/ssh -e none -o 'BatchMode=yes' -o 'HostKeyAlias=apollo' -o 'UserKnownHostsFile=/etc/pve/nodes/apollo/ssh_known_hosts' -o 'GlobalKnownHostsFile=none' root@10.0.2.11 -- pvesm import local-zfs:vm-110-disk-2 zfs - -with-snapshots 0 -snapshot __migration__ -delete-snapshot __migration__ -allow-rename 1' failed: exit code 2
TASK ERROR: migration aborted
```

Adding this dependency fixes that issue.