### PR TITLE
Get backups working

### DIFF
--- a/modules/proxmox-ve/default.nix
+++ b/modules/proxmox-ve/default.nix
@@ -90,7 +90,7 @@ in
       };
       users.groups.www-data = { };
 
-      environment.systemPackages = [ cfg.package pkgs.proxmox-ve pkgs.pve-qemu pkgs.cifs-utils pkgs.samba];
+      environment.systemPackages = [ cfg.package ];
       environment.etc.issue.enable = false;
 
       networking.firewall = mkIf cfg.openFirewall {

--- a/modules/proxmox-ve/default.nix
+++ b/modules/proxmox-ve/default.nix
@@ -66,7 +66,7 @@ in
       };
       users.groups.www-data = { };
 
-      environment.systemPackages = [ pkgs.proxmox-ve ];
+      environment.systemPackages = [ pkgs.proxmox-ve pkgs.pve-qemu pkgs.cifs-utils pkgs.samba];
       environment.etc.issue.enable = false;
 
       networking.firewall.allowedTCPPorts = [

--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -145,6 +145,15 @@ lib.mkIf config.services.proxmox-ve.enable {
       };
     };
 
+    qmeventd = {
+      description = "PVE Qemu Event Daemon";
+      before = [ "pve-ha-lrm.service" "pve-guests.service" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.proxmox-ve}/bin/qmeventd /var/run/qmeventd.sock";
+        Type = "forking";
+      };
+    };
+
     # pvenetcommit = {
     #   description = "Commit Proxmox VE network changes";
     #   wantedBy = [ "multi-user.target" ];

--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -124,6 +124,7 @@ lib.mkIf cfg.enable {
         "pve-guests.service"
         "pve-storage.target"
       ];
+      path = with pkgs; [ btrfs-progs zfs ];
       serviceConfig = {
         ExecStartPre = [
           "${pkgs.coreutils}/bin/touch /var/lib/pve-manager/pve-replication-state.lck"

--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -69,7 +69,6 @@ lib.mkIf cfg.enable {
       wantedBy = [ "multi-user.target" ];
       wants = [
         "pvestatd.service"
-        "qmeventd.service"
         "pveproxy.service"
         "spiceproxy.service"
         "pve-firewall.service"
@@ -78,7 +77,6 @@ lib.mkIf cfg.enable {
       after = [
         "pveproxy.service"
         "pvestatd.service"
-        "qmeventd.service"
         "spiceproxy.service"
         "pve-firewall.service"
         "lxc.service"
@@ -150,15 +148,6 @@ lib.mkIf cfg.enable {
         ExecStop = "${cfg.package}/bin/pvestatd stop";
         ExecReload = "${cfg.package}/bin/pvestatd restart";
         PIDFile = "/run/pvestatd.pid";
-        Type = "forking";
-      };
-    };
-
-    qmeventd = {
-      description = "PVE Qemu Event Daemon";
-      before = [ "pve-ha-lrm.service" "pve-guests.service" ];
-      serviceConfig = {
-        ExecStart = "${pkgs.proxmox-ve}/bin/qmeventd /var/run/qmeventd.sock";
         Type = "forking";
       };
     };

--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -63,6 +63,7 @@ lib.mkIf config.services.proxmox-ve.enable {
       wantedBy = [ "multi-user.target" ];
       wants = [
         "pvestatd.service"
+        "qmeventd.service"
         "pveproxy.service"
         "spiceproxy.service"
         "pve-firewall.service"
@@ -71,6 +72,7 @@ lib.mkIf config.services.proxmox-ve.enable {
       after = [
         "pveproxy.service"
         "pvestatd.service"
+        "qmeventd.service"
         "spiceproxy.service"
         "pve-firewall.service"
         "lxc.service"

--- a/pkgs/cstream/default.nix
+++ b/pkgs/cstream/default.nix
@@ -1,28 +1,33 @@
-{ lib, stdenv, fetchurl, ... }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  ...
+}:
 
 stdenv.mkDerivation rec {
-    pname = "cstream";
-    version = "4.0.0";
-  
-    src = fetchurl {
-      url = "https://www.cons.org/cracauer/download/cstream-${version}.tar.gz";
-      sha256 = "sha256-a8BtfEOG+5jTqRcTQ0wxXZ5tQlyRyIYoG+qiVMDgluM=";
-    };
-    
-    buildInputs = [ stdenv.cc ];
+  pname = "cstream";
+  version = "4.0.0";
 
-    buildPhase = ''
-      make
-    '';
+  src = fetchurl {
+    url = "https://www.cons.org/cracauer/download/cstream-${version}.tar.gz";
+    sha256 = "sha256-a8BtfEOG+5jTqRcTQ0wxXZ5tQlyRyIYoG+qiVMDgluM=";
+  };
 
-    installPhase = ''
-      mkdir -p $out/bin
-      cp cstream $out/bin
-    '';
+  buildInputs = [ stdenv.cc ];
 
-    meta = {
-      description = "A general-purpose stream-handling tool like dd";
-      homepage = "https://www.cons.org/cracauer/cstream.html";
-      maintainers = with lib.maintainers; [ ];
-    };
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp cstream $out/bin
+  '';
+
+  meta = {
+    description = "A general-purpose stream-handling tool like dd";
+    homepage = "https://www.cons.org/cracauer/cstream.html";
+    maintainers = with lib.maintainers; [ ];
+  };
 }

--- a/pkgs/cstream/default.nix
+++ b/pkgs/cstream/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchurl, ... }:
+
+stdenv.mkDerivation rec {
+    pname = "cstream";
+    version = "4.0.0";
+  
+    src = fetchurl {
+      url = "https://www.cons.org/cracauer/download/cstream-${version}.tar.gz";
+      sha256 = "sha256-a8BtfEOG+5jTqRcTQ0wxXZ5tQlyRyIYoG+qiVMDgluM=";
+    };
+    
+    buildInputs = [ stdenv.cc ];
+
+    buildPhase = ''
+      make
+    '';
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp cstream $out/bin
+    '';
+
+    meta = {
+      description = "A general-purpose stream-handling tool like dd";
+      homepage = "https://www.cons.org/cracauer/cstream.html";
+      maintainers = with lib.maintainers; [ ];
+    };
+}

--- a/pkgs/cstream/default.nix
+++ b/pkgs/cstream/default.nix
@@ -14,17 +14,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-a8BtfEOG+5jTqRcTQ0wxXZ5tQlyRyIYoG+qiVMDgluM=";
   };
 
-  buildInputs = [ stdenv.cc ];
-
-  buildPhase = ''
-    make
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp cstream $out/bin
-  '';
-
   meta = {
     description = "A general-purpose stream-handling tool like dd";
     homepage = "https://www.cons.org/cracauer/cstream.html";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -28,6 +28,7 @@ let
     termproxy = callPackage ./termproxy { };
     unifont_hex = callPackage ./unifont { };
     vncterm = callPackage ./vncterm { };
+    cstream = callPackage ./cstream { };
 
     proxmox-acme = callPackage ./proxmox-acme { };
     proxmox-backup = callPackage ./proxmox-backup { };

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -17,6 +17,7 @@
   openvswitch,
   openssh,
   pve-qemu,
+  pve-qemu-server,
   tzdata,
   pve-novnc,
   pve-xtermjs,
@@ -24,6 +25,9 @@
   termproxy,
   shadow,
   wget,
+  bash,
+  zstd,
+  system-sendmail, rsync, busybox, cstream, lvm2
 }:
 
 let
@@ -35,6 +39,7 @@ let
     proxmox-acme
     pve-ha-manager
     pve-http-server
+    pve-qemu-server
   ];
 
   perlEnv = perl536.withPackages (_: perlDeps);
@@ -108,7 +113,9 @@ perl536.pkgs.toPerlModule (
         -e "s|/usr/share/zoneinfo|${tzdata}/share/zoneinfo|" \
         -e "s|/usr/share/pve-xtermjs|${pve-xtermjs}/share/pve-xtermjs|" \
         -Ee "s|(/usr)?/s?bin/||" \
-        -e "s|/usr/share/novnc-pve|${pve-novnc}/share/webapps/novnc|" 
+        -e "s|/usr/share/novnc-pve|${pve-novnc}/share/webapps/novnc|" \
+        -e "s|/usr/share/perl5/.plug|${pve-qemu-server}/${perl536.libPrefix}/${perl536.version}/\$plug|"
+
 
       find $out/bin -type f | xargs sed -i \
         -e "/ENV{'PATH'}/d"
@@ -128,6 +135,9 @@ perl536.pkgs.toPerlModule (
               pve-ha-manager
               shadow
               wget
+
+              ## dependencies of backup and restore
+              bash zstd system-sendmail rsync busybox cstream lvm2
             ]
           } \
           --prefix PERL5LIB : $out/${perl536.libPrefix}/${perl536.version}

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -163,12 +163,12 @@ perl538.pkgs.toPerlModule (
 
               ## dependencies of backup and restore
               bash
-              zstd
-              system-sendmail
-              rsync
               busybox
               cstream
               lvm2
+              rsync
+              system-sendmail
+              zstd
             ]
           } \
           --prefix PERL5LIB : $out/${perl538.libPrefix}/${perl538.version}

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -35,6 +35,7 @@
   busybox,
   cstream,
   lvm2,
+  lxc,
   libfaketime,
   corosync,
   openssl,
@@ -166,6 +167,7 @@ perl538.pkgs.toPerlModule (
               busybox
               cstream
               lvm2
+              lxc
               rsync
               system-sendmail
               zstd

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -9,6 +9,7 @@
   pve-docs,
   pve-ha-manager,
   pve-http-server,
+  cdrkit,
   ceph,
   gnupg,
   graphviz,
@@ -125,6 +126,7 @@ perl536.pkgs.toPerlModule (
           --prefix PATH : ${
             lib.makeBinPath [
               ceph
+              cdrkit ## cloud-init
               gzip
               openssh
               gnupg

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -19,7 +19,6 @@
   openvswitch,
   openssh,
   pve-qemu,
-  pve-qemu-server,
   tzdata,
   pve-novnc,
   pve-xtermjs,
@@ -51,7 +50,6 @@ let
     proxmox-acme
     (pve-ha-manager.override { inherit enableLinstor; })
     pve-http-server
-    pve-qemu-server
   ];
 
   perlEnv = perl538.withPackages (_: perlDeps);
@@ -127,7 +125,7 @@ perl538.pkgs.toPerlModule (
         -Ee "s|(/usr)?/s?bin/||" \
         -e "s|/usr/share/novnc-pve|${pve-novnc}/share/webapps/novnc|" \
         -e "s/Ceph Nautilus required/Ceph Nautilus required - PATH: \$ENV{PATH}\\\n/" \
-        -e "s|/usr/share/perl5/.plug|${pve-qemu-server}/${perl538.libPrefix}/${perl538.version}/\$plug|"
+        -e "s|/usr/share/perl5/\\\$plug|/run/current-system/sw/${perl538.libPrefix}/${perl538.version}/\$plug|"
 
       # Ceph systemd units in NixOS do not use templates
       find $out/lib -type f -wholename "*Ceph*" | xargs sed -i -e "s/\\\@/-/g"

--- a/pkgs/pve-storage/default.nix
+++ b/pkgs/pve-storage/default.nix
@@ -11,6 +11,7 @@
   file,
   glusterfs,
   gptfdisk,
+  gzip,
   libiscsi,
   lvm2,
   nfs-utils,
@@ -102,6 +103,8 @@ perl536.pkgs.toPerlModule (
         -e "s|/usr/bin/smbclient|${samba}/bin/smbclient|" \
         -e "s|/usr/bin/ssh|${openssh}/bin/ssh|" \
         -e "s|/usr/bin/targetcli|${targetcli}/bin/targetcli|" \
+        -e "s|/usr/bin/vma|${pve-qemu}/bin/vma|" \
+        -e "s|/usr/bin/zcat|${gzip}/bin/zcat|" \
         -e "s|/usr/libexec/ceph|$out/libexec/ceph|" \
         -re "s|/usr/s?bin/ceph|${ceph}/bin/ceph|" \
         -e "s|/usr/sbin/gluster|${glusterfs}/bin/gluster|" \


### PR DESCRIPTION
This is built on the work done in #45, plus:

- Fixes merge conflicts
- Removes some unneeded phases from the new cstream derivation
- Removes the `qmeventd` changes that aren't needed anymore
- Changes the plugin search path replacement to look under `/run/current-system/sw/lib`, so it will be able to find the plugins for both VMs and LXC containers
- Add `lxc` to the path for vzdump, since it will now check the path for LXC tools since the LXC plugin is getting loaded
- Add `zfs` and `btrfs-progs` to the `pvescheduler` service path, similar to other `pve-manager` services. I found my scheduled jobs didn't work even though the ones triggered manually did, and it seems like this is why.