### PR TITLE
ssh: add explicit host filter before SendEnv

### DIFF
--- a/modules/proxmox-ve/default.nix
+++ b/modules/proxmox-ve/default.nix
@@ -73,7 +73,8 @@ in
         settings.AcceptEnv = "LANG LC_*";
       };
       programs.ssh.extraConfig = ''
-        SendEnv LANG LC_*
+        Host *
+          SendEnv LANG LC_*
       '';
 
       security.pam.services."proxmox-ve-auth" = {


### PR DESCRIPTION
The `SendEnv` setting here is assuming there isn't some other `Host` filters in `programs.ssh.extraConfig` that will appear before it, but that wasn't the case on my systems, as I have some host-specific configuration included. Adding `Host *` before `SendEnv` will ensure that no matter where it appears, it will still apply to all hosts.

Without this, the VNC proxy to other nodes in the cluster was failing because it wasn't sending the ticket along in the `LC_PVE_TICKET` env var.