### PR TITLE
pve-edk2-firmware: 4.2023.08-4 -> 4.2025.02-2

### DIFF
--- a/pkgs/pve-edk2-firmware/default.nix
+++ b/pkgs/pve-edk2-firmware/default.nix
@@ -11,12 +11,12 @@
 
 stdenv.mkDerivation rec {
   pname = "pve-edk2-firmware";
-  version = "4.2025.02-1";
+  version = "4.2025.02-2";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/${pname}.git";
-    rev = "cacc8b87677e2cb06a9dfc91968cb977877b39fa";
-    sha256 = "sha256-4blx/bHpP9vlQO2Rz9zLAk1rkl56PAJW978kU20hKzs=";
+    rev = "b00cde11d82743780b6be587d71c6aaa0ea52d03";
+    sha256 = "sha256-vqGjsy/JOYphLoRtkSKP0eNfVlsIXABTlI4vsIiocPw=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/pve-edk2-firmware/default.nix
+++ b/pkgs/pve-edk2-firmware/default.nix
@@ -5,48 +5,44 @@
   pkgsCross,
   stdenv, 
   fetchgit,
+  writeShellScriptBin,
   ... 
 }:
 
 stdenv.mkDerivation rec {
   pname = "pve-edk2-firmware";
-  version = "4.2023.08-4";
+  version = "4.2025.02-1";
 
-  src = fetchgit rec {
+  src = fetchgit {
     url = "git://git.proxmox.com/git/${pname}.git";
-    rev = "17443032f78eaf9ae276f8df9d10c64beec2e048";
-    sha256 = "sha256-efDcC+kdCXDf64N+kNXDQIpsCiAUP2DyKmXZCpx5MAo=";
-
-    # FIXME: remove manual fetch submodule if submodule url fixed in next release
-    fetchSubmodules = false;
-    leaveDotGit = true;
-
-    postFetch = ''
-      cd $out
-      git remote add origin ${url}
-      git fetch
-      git branch --set-upstream-to=origin/master
-      git reset --hard ${rev}
-
-      sed -i "s#../mirror_edk2#git://git.proxmox.com/git/mirror_edk2.git#g" .gitmodules
-      git submodule sync
-      git submodule update --init --depth 1
-      ls -lah edk2
-      sed -i "s#github.com/Zeex/subhook#github.com/tianocore/edk2-subhook#g" edk2/.gitmodules
-      git submodule update --init --recursive
-      git clean -fxd
-      rm -rf .git/
-    '';
+    rev = "cacc8b87677e2cb06a9dfc91968cb977877b39fa";
+    sha256 = "sha256-4blx/bHpP9vlQO2Rz9zLAk1rkl56PAJW978kU20hKzs=";
+    fetchSubmodules = true;
   };
 
   buildInputs = [ ];
 
-  hardeningDisable = [ "format" "fortify" "trivialautovarinit" ];
+  hardeningDisable = [ 
+    "format" 
+    "fortify" 
+    "trivialautovarinit" 
+  ];
 
   nativeBuildInputs = with pkgs; [
-    dpkg fakeroot qemu
-    bc dosfstools acpica-tools mtools nasm libuuid
-    qemu-utils libisoburn python3
+    dpkg
+    fakeroot 
+    qemu
+    bc 
+    dosfstools 
+    acpica-tools 
+    mtools 
+    nasm 
+    libuuid
+    qemu-utils 
+    libisoburn 
+    python3
+    # Mock debhelper
+    (writeShellScriptBin "dh" "true") 
   ] ++ (lib.optional (stdenv.hostPlatform.system != "aarch64-linux") pkgsCross.aarch64-multiplatform.stdenv.cc)
     ++ (lib.optional (stdenv.hostPlatform.system != "x86_64-linux") pkgsCross.gnu64.stdenv.cc)
     ++ (lib.optional (stdenv.hostPlatform.system != "riscv64-linux") pkgsCross.riscv64.stdenv.cc);
@@ -66,10 +62,6 @@ stdenv.mkDerivation rec {
       substituteInPlace ./debian/rules \
         --replace-warn 'PYTHONPATH=$(CURDIR)/debian/python' 'PYTHONPATH=$(CURDIR)/debian/python:${pythonPath}'
 
-      # Skip dh calls because we don't need debhelper
-      substituteInPlace ./debian/rules \
-        --replace-warn 'dh $@' ': dh $@'
-
       # Patch cross compiler paths
       substituteInPlace ./debian/rules ./**/CMakeLists.txt \
         --replace-warn 'aarch64-linux-gnu-' '${pkgsCross.aarch64-multiplatform.stdenv.cc.targetPrefix}'
@@ -78,16 +70,11 @@ stdenv.mkDerivation rec {
       sed -i '/^EDK2_TOOLCHAIN *=/a export $(EDK2_TOOLCHAIN)_BIN=${pkgsCross.gnu64.stdenv.cc.targetPrefix}' ./debian/rules
     '';
 
-  buildPhase = 
-    let
-      mainVersion = builtins.head (lib.splitString "-" version);
-    in
-    ''
-      make ${pname}_${mainVersion}.orig.tar.gz
-      pushd ${pname}-${mainVersion}
-      dpkg-source -b .
-      make -f debian/rules override_dh_auto_build
-    '';
+  buildPhase = ''
+    mv ./debian ./edk2
+    pushd ./edk2
+    make -f ./debian/rules override_dh_auto_build
+  '';
 
   installPhase = ''
     # Copy files as mentioned in *.install files
@@ -124,6 +111,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "edk2 based UEFI firmware modules for virtual machines";
     homepage = "git://git.proxmox.com/git/${pname}.git";
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ codgician ];
   };
  }

--- a/pkgs/pve-edk2-firmware/default.nix
+++ b/pkgs/pve-edk2-firmware/default.nix
@@ -111,6 +111,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "edk2 based UEFI firmware modules for virtual machines";
     homepage = "git://git.proxmox.com/git/${pname}.git";
-    maintainers = with lib.maintainers; [ codgician ];
+    maintainers = with lib.maintainers; [ codgician julienmalka ];
   };
  }


### PR DESCRIPTION
- Bumped `pve-edk2-firmware` to 4.2025.02-1
- Reverted changes in #79 because the issue has been fixed upstream. Kudos to @5aaee9 for the mitigation.
- Some readability improvements and added myself as maintainer for this package.

/cc maintainers @camillemndn @JulienMalka