### PR TITLE
pve-manager: fix ordering acme certificate

### DIFF
--- a/pkgs/proxmox-acme/default.nix
+++ b/pkgs/proxmox-acme/default.nix
@@ -4,6 +4,8 @@
   fetchgit,
   perl538,
   acme-sh,
+  bash,
+  curl,  
 }:
 
 let
@@ -27,6 +29,13 @@ perl538.pkgs.toPerlModule (
     sourceRoot = "${src.name}/src";
 
     postPatch = ''
+      # Remove --reset-env so basic coreutils tools could be found
+      substituteInPlace PVE/ACME/DNSChallenge.pm \
+        --replace-fail ', "--reset-env"' "" \
+        --replace-fail '/bin/bash' '${lib.getExe bash}'
+      substituteInPlace proxmox-acme \
+        --replace-fail '_CURL="curl' '_CURL="${lib.getExe curl}' 
+
       sed -i Makefile -e "s,acme.sh,${acme-sh}/libexec,"
     '';
 

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -44,6 +44,7 @@
 
 let
   perlDeps = with perl538.pkgs; [
+    CryptOpenSSLBignum
     FileReadBackwards
     NetDNS
     PodParser


### PR DESCRIPTION
Fixes an issue mentioned on [NixOS discourse](https://discourse.nixos.org/t/announcing-proxmox-nixos/47579/14), where adding ACME account is failing with following error message:

```
TASK ERROR: Registration failed: Can't locate object method "bless_pointer" via package "Crypt::OpenSSL::Bignum" at blib/lib/Crypt/OpenSSL/RSA.pm (autosplit into blib/lib/auto/Crypt/OpenSSL/RSA/get_key_parameters.al) line 330. 
```

Following changes are made in this PR:

* [pve-manager] added missing perl dependency [CryptOpenSSLBignum](https://metacpan.org/dist/Crypt-OpenSSL-Bignum).
* [pve-acme] removed `--reset-env` when invoking `setpriv` so basic coreutils binaries could be discovered.
* [pve-acme] patched hardcoded paths for bash and curl.

Tested locally:

![image](https://github.com/user-attachments/assets/814ca49a-ff85-4b5a-81e8-cbc79bc1a4d5)

<img width="843" alt="image" src="https://github.com/user-attachments/assets/48320aef-7561-4b28-8a37-49e8f9e2a60f" />

