### PR TITLE
pve-qemu-server: fix libEGL/libGL detection to make VirGL work

### DIFF
--- a/pkgs/pve-qemu-server/default.nix
+++ b/pkgs/pve-qemu-server/default.nix
@@ -16,6 +16,7 @@
   socat,
   vncterm,
   swtpm,
+  libglvnd,
 }:
 
 let
@@ -75,6 +76,9 @@ perl538.pkgs.toPerlModule (
 
       # Fix QEMU version check
       sed -i PVE/QemuServer.pm -e "s/\[,\\\s\]//"
+
+      # Fix libGL and libEGL detection
+      sed -i PVE/QemuServer.pm -e "s|/usr/lib/x86_64-linux-gnu/lib|${libglvnd}/lib/lib|"
     '';
 
     buildInputs = [


### PR DESCRIPTION
This PR patches the VirGL library detection logic in pve-qemu-server [Line 1835 of QemuServer.pm](https://git.proxmox.com/?p=qemu-server.git;a=blob;f=PVE/QemuServer.pm;h=82e7d6a6b0dc1e0ef9bad734901f0fe27e4da461;hb=54aa98cea5071b5cd325cfaeb21b7aaa4af9bb4d#l1835) to make VirGL virtualized graphics work.

Tested locally. Before this PR:

![image](https://github.com/user-attachments/assets/bcc45a71-ce52-4bc9-950e-dfb5b8e271f6)

After this PR:

![image](https://github.com/user-attachments/assets/65c15aa1-0ce1-4afb-bd5e-8391346156cc)

