### PR TITLE
proxmox-backup-qemu: remove leaveDotGit

### DIFF
--- a/pkgs/proxmox-backup-qemu/default.nix
+++ b/pkgs/proxmox-backup-qemu/default.nix
@@ -26,9 +26,8 @@ rustPlatform.buildRustPackage rec {
   src = fetchgit {
     url = "git://git.proxmox.com/git/${pname}.git";
     rev = "c3cbcae289d04b4454a70fc59dc58a19d5edb681";
-    hash = "sha256-rbKKcPwswZoIAFGdW9SxG2goHC4U8TG0pYQl1M6jku0=";
+    hash = "sha256-qynY7bt+lOzpg4YxeUnRk7/xoSbtk+tWGbuNMmAdzHY=";
     fetchSubmodules = true;
-    leaveDotGit = true;
   };
 
   patches = [ ./backup-toml.patch ];


### PR DESCRIPTION
leaveDotGit was hurting hash stability, and is not necessary anymore

Better version of #152 