### PR TITLE
Upgrade pve-manager and related core packages to versions around Jan. 2025

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -34,6 +34,7 @@ let
 
     proxmox-acme = callPackage ./proxmox-acme { };
     proxmox-backup-qemu = callPackage ./proxmox-backup-qemu { };
+    proxmox-i18n = callPackage ./proxmox-i18n { };
     proxmox-ve = callPackage ./proxmox-ve { };
     proxmox-widget-toolkit = callPackage ./proxmox-widget-toolkit { };
 

--- a/pkgs/proxmox-i18n/default.nix
+++ b/pkgs/proxmox-i18n/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  perl538,
+}:
+
+let
+  perlDeps = with perl538.pkgs; [
+    Encode
+    GetoptLong
+    JSON
+    LocalePO
+  ];
+
+  perlEnv = perl538.withPackages (_: perlDeps);
+in
+stdenv.mkDerivation rec {
+  pname = "proxmox-i18n";
+  version = "3.2.4";
+
+  src = fetchgit {
+    url = "git://git.proxmox.com/git/${pname}.git";
+    rev = "80a4665aa333807539a491cce7feef3f62ffe8aa";
+    hash = "sha256-CGH6ceUJVHdljKMDofPWVXHSNA0XOiUVLmZL6Gjkm60=";
+  };
+ 
+  postPatch = ''
+    # Remove dpkg pkg-info.mk targets
+    substituteInPlace ./Makefile \
+      --replace-fail 'include /usr/share/dpkg/pkg-info.mk' ""
+    substituteInPlace ./Makefile \
+      --replace-fail '/usr/share' '/share'
+    patchShebangs .
+  '';
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+  ];
+
+  nativeBuildInputs = [ perlEnv ];
+
+  passthru.updateScript = [
+    ../update.py
+    pname
+    "--url"
+    src.url
+  ];
+
+  meta = with lib; {
+    description = "";
+    homepage = "git://git.proxmox.com/?p=proxmox-i18n.git";
+    license = [ ];
+    maintainers = with maintainers; [ ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/pve-access-control/default.nix
+++ b/pkgs/pve-access-control/default.nix
@@ -19,12 +19,12 @@ in
 perl538.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-access-control";
-    version = "8.2.0";
+    version = "8.2.2";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "de84a7894b61de8fce49539a853c3dd7d5154028";
-      hash = "sha256-jnq/VDRRN5l+D94FDGUdwEcmT8v7ZPVru3RvuWGHeP0=";
+      rev = "25dd3756f90afbf65799da4708b3df9c2bf7e9f6";
+      hash = "sha256-gmTlDvOTPeFNB2W0H3xHZBWsRFY6XeIb0r/1qNzsphA=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-common/0002-mknod-mknodat.patch
+++ b/pkgs/pve-common/0002-mknod-mknodat.patch
@@ -12,15 +12,15 @@ index 9ef3d5d..dca8b4f 100644
  	setresuid => &SYS_setresuid,
  	fchownat => &SYS_fchownat,
 diff --git a/PVE/Tools.pm b/PVE/Tools.pm
-index 766c809..643a05d 100644
+index 0325f53..b05d0ff 100644
 --- a/PVE/Tools.pm
 +++ b/PVE/Tools.pm
-@@ -1753,7 +1753,7 @@ sub mkdirat($$$) {
+@@ -1787,7 +1787,7 @@ sub mkdirat($$$) {
  
  sub mknod($$$) {
      my ($filename, $mode, $dev) = @_;
--    return syscall(PVE::Syscall::SYS_mknod, $filename, int($mode), int($dev)) == 0;
-+    return syscall(PVE::Syscall::SYS_mknodat, 'AT_FDCWD', $filename, int($mode), int($dev)) == 0;
+-    return syscall(PVE::Syscall::mknod, $filename, int($mode), int($dev)) == 0;
++    return syscall(PVE::Syscall::mknodat, $filename, int($mode), int($dev)) == 0;
  }
  
  sub fchownat($$$$$) {

--- a/pkgs/pve-common/default.nix
+++ b/pkgs/pve-common/default.nix
@@ -71,12 +71,12 @@ in
 perl538.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-common";
-    version = "8.2.1";
+    version = "8.2.9";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "1a6005ad2377b6586e084b3840ac622752b666b8";
-      hash = "sha256-fMgkeaOoaJDk9yf3O4uZSTs0p7H4uUYyy1Ii3J02uNw=";
+      rev = "5d5b3abe6da80c5eea5233bd1486246acc9e12ab";
+      hash = "sha256-ODFyNWUnVr8Yo3hZZAIFRlpkMutN9Hx+6uDqFncA7pg=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-common/default.nix
+++ b/pkgs/pve-common/default.nix
@@ -71,12 +71,12 @@ in
 perl538.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-common";
-    version = "8.2.9";
+    version = "8.3.1";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "5d5b3abe6da80c5eea5233bd1486246acc9e12ab";
-      hash = "sha256-ODFyNWUnVr8Yo3hZZAIFRlpkMutN9Hx+6uDqFncA7pg=";
+      rev = "85d46b41030f538e1e42b570187b0aea3f3f6afd";
+      hash = "sha256-kSx0mSP5Htcid2a/bNPNFCsy4jURc/NDHHILWXpQIlk=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-guest-common/default.nix
+++ b/pkgs/pve-guest-common/default.nix
@@ -8,12 +8,12 @@
 perl538.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-guest-common";
-    version = "5.1.6";
+    version = "5.1.7";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "4c2dd7c226ee3268bc144bbb9b639637f0981ff2";
-      hash = "sha256-NbJBKb4az62esyb8D3iMw+3I5U+XnfEyaK0XQxu5hv8=";
+      rev = "90edabc8168ce685ede004abcf93f12795832ba9";
+      hash = "sha256-7R56F0zg9q0B+STbFs/csxH3YYtb2hKqkFYRF9hRWwA=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -60,12 +60,12 @@ in
 perl538.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-manager";
-    version = "8.2.4";
+    version = "8.2.10";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "faa83925c96413258b9a02c4de89442adeff9215";
-      hash = "sha256-onNnxvQ7YrdnrFpl+z7Z+xUyEZsMcU6Qxn/kjYLan+8=";
+      rev = "536023790079895fdac20da75a767be5f3c38295";
+      hash = "sha256-BtBm2x0OEGvF1Sl/iA9di8Ip8TjyavZ/aTLhNHQiKbU=";
     };
 
     patches = [
@@ -121,6 +121,7 @@ perl538.pkgs.toPerlModule (
         -e "/ENV{'PATH'}/d" \
         -e "s|/usr/share/javascript|${pve-http-server}/share/javascript|" \
         -e "s|/usr/share/fonts-font-awesome|${pve-http-server}/share/fonts-font-awesome|" \
+        -e "s|/usr/share/fonts-font-logos|${pve-http-server}/share/fonts-font-logos|" \
         -e "s|/usr/share/pve-manager|$out/share/pve-manager|" \
         -e "s|/usr/share/zoneinfo|${tzdata}/share/zoneinfo|" \
         -e "s|/usr/share/pve-xtermjs|${pve-xtermjs}/share/pve-xtermjs|" \

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -6,6 +6,7 @@
   perl538,
   proxmox-widget-toolkit,
   proxmox-acme,
+  proxmox-i18n,
   pve-docs,
   pve-ha-manager,
   pve-http-server,
@@ -60,12 +61,12 @@ in
 perl538.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-manager";
-    version = "8.2.10";
+    version = "8.3.5";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "536023790079895fdac20da75a767be5f3c38295";
-      hash = "sha256-BtBm2x0OEGvF1Sl/iA9di8Ip8TjyavZ/aTLhNHQiKbU=";
+      rev = "dac3aa88bac3f3004bc793eaaf8b27b820043605";
+      hash = "sha256-GaAeEwDyxFtLz5+zLD0FPadRZftVHNNDJhZCJSFCl78=";
     };
 
     patches = [
@@ -122,6 +123,7 @@ perl538.pkgs.toPerlModule (
         -e "s|/usr/share/javascript|${pve-http-server}/share/javascript|" \
         -e "s|/usr/share/fonts-font-awesome|${pve-http-server}/share/fonts-font-awesome|" \
         -e "s|/usr/share/fonts-font-logos|${pve-http-server}/share/fonts-font-logos|" \
+        -e "s|/usr/share/pve-i18n|${proxmox-i18n}/share/pve-i18n|" \
         -e "s|/usr/share/pve-manager|$out/share/pve-manager|" \
         -e "s|/usr/share/zoneinfo|${tzdata}/share/zoneinfo|" \
         -e "s|/usr/share/pve-xtermjs|${pve-xtermjs}/share/pve-xtermjs|" \


### PR DESCRIPTION
This PR aims to upgrade pve-manager and related core packages one step at a time, since many iterations have happened in the past few months.

* proxmox-i18n: init at 3.2.4
* pve-manager: 8.2.4 -> 8.3.5
* pve-common: 8.2.1 -> 8.3.1
* pve-guest-common: 5.1.6 -> 5.1.7
* pve-access-control: 8.2.0 -> 8.2.2

