### PR TITLE
Fixed nixmoxer crash when there are no VMs on the cluster

### DIFF
--- a/pkgs/nixmoxer/main.py
+++ b/pkgs/nixmoxer/main.py
@@ -153,6 +153,8 @@ class Proxmox:
             bool: True if the VM ID exists, False otherwise.
         """
         vms = self.list_vms_on_cluster()
+        if (len(vms) == 0):
+            return False, None, None
         ids, names, nodes = zip(*vms)
         if vmid in ids:
             index = ids.index(vmid)
@@ -170,6 +172,8 @@ class Proxmox:
             bool: True if the VM ID exists, False otherwise.
         """
         vms = self.list_vms_on_cluster()
+        if (len(vms) == 0):
+            return False, None, None
         ids, names, nodes = zip(*vms)
         if vm_name in names:
             index = names.index(vm_name)


### PR DESCRIPTION
The methods vmid_exists and vm_name_exists crash with the error message `ValueError: not enough values to unpack (expected 3, got 0)` when the cluster contains no VMs.

This is because `tuple(zip())` (which is essentially what happens when there are no VMs) will return an empty tuple which cannot be unpacked. 

I added an extra check to both functions in order to prevent such crashes.