### PR TITLE
pve-rs: 0.9.1 -> 0.9.4

### DIFF
--- a/pkgs/perlmod/Cargo.lock
+++ b/pkgs/perlmod/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "perlmod"
-version = "0.13.6"
+version = "0.13.5"
 dependencies = [
  "bitflags",
  "cc",

--- a/pkgs/perlmod/default.nix
+++ b/pkgs/perlmod/default.nix
@@ -8,12 +8,12 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "perlmod";
-  version = "0.2.0-3";
+  version = "0.2.1-1";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/perlmod.git";
-    rev = "1544fc13d7196152409467db416f1791ed121fc3";
-    hash = "sha256-/HsItWYgSMkqaXHsvsRR3seuHkzWJfBnAR2DDwcvpw4=";
+    rev = "2c5f34aee080675173ce54b557c8785f24b885ab";
+    hash = "sha256-6SoYGQP5ExYiitfO879hDksk9tWLo1W6f98jqQmUznY=";
   };
 
   patches = [ ./remove_safe_putenv.patch ];

--- a/pkgs/pve-rs/Cargo.lock
+++ b/pkgs/pve-rs/Cargo.lock
@@ -1340,7 +1340,7 @@ version = "1.4.0"
 
 [[package]]
 name = "proxmox-log"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "nix",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-notify"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-openid"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "http",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-sys"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "libc",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "pve-rs"
-version = "0.9.1"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "base32",
@@ -1581,7 +1581,6 @@ dependencies = [
  "hex",
  "http",
  "libc",
- "log",
  "nix",
  "openssl",
  "perlmod",

--- a/pkgs/pve-rs/default.nix
+++ b/pkgs/pve-rs/default.nix
@@ -21,12 +21,12 @@ in
 perl538.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-rs";
-    version = "0.9.1";
+    version = "0.9.4";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/proxmox-perl-rs.git";
-      rev = "82bfbbf6c64b3749e3e982d933b9156e638386b2";
-      hash = "sha256-NetS/dDi5PT1TWZbI0pSqc57C4SSgBzbPmeSpquSuTA=";
+      rev = "22a6b226309923ddf6ca1982e813f5a273e0d427";
+      hash = "sha256-YxioQTLVYMSvkZx4pYTjnFto9PhFMODS5ZwLa1Wa/JA=";
     };
 
     cargoDeps = rustPlatform.importCargoLock {

--- a/pkgs/pve-rs/sources.nix
+++ b/pkgs/pve-rs/sources.nix
@@ -288,9 +288,9 @@
   {
     name = "librust-proxmox-log-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "8a1166be4b404a53abf12488a0c5686703eebf43";
+    rev = "e06277ac7a10e1e149345b4cdfa9a485acabc283";
 
-    sha256 = "0hr2py8fbj1wz7fvlgwc2cv4c7xsk32kfrv2ngl981p66fvli73j";
+    sha256 = "166n6igq1cs64y09k0agk4w0rkqif21j8c018h8gvkqhgd4cpycn";
     crates = [
       {
         name = "proxmox-log";
@@ -340,9 +340,9 @@
   {
     name = "librust-proxmox-notify-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "ad3657011eb48ddffba4fa7f8a76cc37558e0a68";
+    rev = "22ffd650c2fac9000f3549930c544e6100c3b1b0";
 
-    sha256 = "1832v4yjpd4jbd17gy76wby8d3yazv1ph1sin2bqsb9ppxkpq049";
+    sha256 = "1vr7lnxg0kv69kjccwyi0nyxd2dav302gnvjkxirppwn5px532g7";
     crates = [
       {
         name = "proxmox-notify";
@@ -353,9 +353,9 @@
   {
     name = "librust-proxmox-openid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "c1a947c99858d7b4544ead662ae559d69172e7b3";
+    rev = "56763c11840926f23fcdd67cf580c02ef4e34ab6";
 
-    sha256 = "0395l0dl4yh9yd9xk6g0v477ba40p51l657ikcjicavcybhwyvbx";
+    sha256 = "1j69d6gaszm3w5wv17h8pnsifmv1aqdzrin2xkcvc6w3l9gs3fa3";
     crates = [
       {
         name = "proxmox-openid";
@@ -535,9 +535,9 @@
   {
     name = "librust-proxmox-sys-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "212249e009a2f6b4312528110aa23f70f4b09f99";
+    rev = "86a517d0875acec90ca1aae71e0a795930308d6d";
 
-    sha256 = "0wjivnia72vf035b9lifqyx959v0r5zfxz5fgi1i2xilyb9ld1dx";
+    sha256 = "11gnhbyp652gkbdv89j4c79zphnjsd548cps35yxqf18ds7vwva3";
     crates = [
       {
         name = "proxmox-sys";


### PR DESCRIPTION
Fixes #167 

This PR bumps following two packages:

* pve-rs: 0.9.1 -> 0.9.4
* perlmod: 0.2.0-3 -> 0.2.1-1

Diff: https://github.com/proxmox/proxmox-perl-rs/compare/82bfbbf6c64b3749e3e982d933b9156e638386b2..22a6b226309923ddf6ca1982e813f5a273e0d427

Notes:

* pve-rs 0.9.4 is an official version that can be found under http://download.proxmox.com/debian/pve/dists/bookworm/pve-no-subscription/binary-amd64/
* perlmod is bumped accordingly to `pve-rs/debian/control` inside above diff.
* OIDC tested to be working:
<img width="1166" height="468" alt="image" src="https://github.com/user-attachments/assets/6d0d9c42-da25-459f-8c9b-35ee2ef01b39" />


