### PR TITLE
Fix nsupdate

### DIFF
--- a/pkgs/proxmox-acme/default.nix
+++ b/pkgs/proxmox-acme/default.nix
@@ -6,6 +6,7 @@
   acme-sh,
   bash,
   curl,
+  bind,
   pve-update-script,
 }:
 
@@ -49,6 +50,8 @@ perl5.pkgs.toPerlModule (
 
     postFixup = ''
       find $out -type f | xargs sed -i -e "s|/usr/share/proxmox-acme|$out/share/proxmox-acme|"
+      substituteInPlace $out/share/proxmox-acme/dnsapi/dns_nsupdate.sh \
+        --replace-fail "    nsupdate" "    ${lib.getExe' bind.dnsutils "nsupdate"}"
     '';
 
     passthru.updateScript = pve-update-script {


### PR DESCRIPTION
Using the nsupdate plugin fails unless the full path to nsupdate is substituted in. This fixes the issue.

Happy for suggestions on how to make this better, as I'm not 100% this is the best way to accomplish this.