### PR TITLE
Don't default to vnc clipboard

### DIFF
--- a/modules/declarative-vms/options.nix
+++ b/modules/declarative-vms/options.nix
@@ -1264,8 +1264,10 @@ in
             example = "std";
           };
           clipboard = mkOption {
-            type = types.enum [ "vnc" ];
-            default = "vnc";
+            type = types.nullOr (
+              types.enum [ "vnc" ]
+            );
+            default = null;
             description = "Enable clipboard sharing for VNC.";
           };
           memory = mkOption {


### PR DESCRIPTION
It's not supported for live migration.
