### PR TITLE
fix: AcceptEnv redefinition in nixpkgs

### DIFF
--- a/modules/proxmox-ve/default.nix
+++ b/modules/proxmox-ve/default.nix
@@ -71,7 +71,7 @@ in
 
       services.openssh = {
         enable = true;
-        settings.AcceptEnv = "LANG LC_*";
+        settings.AcceptEnv = if lib.versionAtLeast pkgs.lib.version "26.05pre-git" then ["LANG" "LC_*"] else "LANG LC_*";
       };
       programs.ssh.extraConfig = ''
         Host *


### PR DESCRIPTION
fixes #212

Updates the settings for AcceptEnv to match the new expectation upstream that the option is a list
