### PR TITLE
use absolute references to flake inputs, reducing impurity from the reference registry

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
-    nixpkgs-stable.url = "nixpkgs/nixos-25.05";
-    nixpkgs-unstable.url = "nixpkgs/nixos-unstable";
-    nixpkgs-libvncserver.url = "nixpkgs/e6f23dc08d3624daab7094b701aa3954923c6bbb";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-libvncserver.url = "github:NixOS/nixpkgs/e6f23dc08d3624daab7094b701aa3954923c6bbb";
     utils.url = "github:numtide/flake-utils";
     flake-compat.url = "github:edolstra/flake-compat";
   };


### PR DESCRIPTION
currently, `inputs` rely on registry reference `nixpkgs`, which is among the [default references](https://github.com/NixOS/flake-registry/blob/master/flake-registry.json).
as such, if one were to locally override those now, that would currently affect the build here as well.
i stumbled upon this myself having overridden this reference for use in local shells, ending up surprised when i found `proxmox-nixos` would change behavior based on this rather than keeping such overrides explicit, as seems to be the common behavior in the ecosystem.
