### PR TITLE
remove unstable branch, preventing accidental branch reuse to patch different (future) issues

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,27 +45,11 @@
         "type": "indirect"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1761114652,
-        "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "01f116e4df6a15f4ccdffb1bcd41096869fb385c",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
-      }
-    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
         "nixpkgs-libvncserver": "nixpkgs-libvncserver",
         "nixpkgs-stable": "nixpkgs-stable",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "utils": "utils"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
     nixpkgs-stable.url = "nixpkgs/nixos-25.05";
-    nixpkgs-unstable.url = "nixpkgs/nixos-unstable";
     nixpkgs-libvncserver.url = "nixpkgs/e6f23dc08d3624daab7094b701aa3954923c6bbb";
     utils.url = "github:numtide/flake-utils";
     flake-compat.url = "github:edolstra/flake-compat";
@@ -16,7 +15,6 @@
     {
       self,
       nixpkgs-stable,
-      nixpkgs-unstable,
       nixpkgs-libvncserver,
       utils,
       ...
@@ -42,16 +40,11 @@
                 (_: _: { inherit (nixpkgs-libvncserver.legacyPackages.${system}) libvncserver; })
               ];
             };
-
-            pkgs-unstable = import nixpkgs-unstable {
-              inherit system;
-              overlays = [ ];
-            };
           in
           {
-            overlays = _: _: (import ./pkgs { inherit pkgs pkgs-unstable; });
+            overlays = _: _: (import ./pkgs { inherit pkgs; });
 
-            packages = utils.lib.filterPackages system (import ./pkgs { inherit pkgs pkgs-unstable; });
+            packages = utils.lib.filterPackages system (import ./pkgs { inherit pkgs; });
 
             checks =
               if (system == "x86_64-linux") then

--- a/tasks/update.nix
+++ b/tasks/update.nix
@@ -31,27 +31,6 @@ let
           { overlays = include-overlays; }
       );
 
-  pkgs-unstable =
-    import
-      (
-        let
-          lock = builtins.fromJSON (builtins.readFile ../flake.lock);
-          nixpkgsName = lock.nodes.root.inputs.nixpkgs-unstable;
-        in
-        fetchTarball {
-          url = "https://github.com/NixOS/nixpkgs/archive/${lock.nodes.${nixpkgsName}.locked.rev}.tar.gz";
-          sha256 = lock.nodes.${nixpkgsName}.locked.narHash;
-        }
-      )
-      (
-        if !include-overlays then
-          { overlays = [ ]; }
-        else if include-overlays then
-          { } # Let Nixpkgs include overlays impurely.
-        else
-          { overlays = include-overlays; }
-      );
-
   lock = builtins.fromJSON (builtins.readFile ../flake.lock);
   crane = fetchTarball {
     url = "https://github.com/ipetkov/crane/${lock.nodes.crane.locked.rev}.tar.gz";
@@ -59,7 +38,7 @@ let
   };
   craneLib = import crane { inherit pkgs; };
 
-  ourpkgs = import ../pkgs { inherit pkgs pkgs-unstable craneLib; };
+  ourpkgs = import ../pkgs { inherit pkgs craneLib; };
   inherit (pkgs) lib;
 
   # Remove duplicate elements from the list based on some extracted value. O(n^2) complexity.


### PR DESCRIPTION
currently the repo's inputs include an unstable branch, which at present is not actually in use for any patches, pulling in a potentially new nixpkgs revision that currently does not do anything.

while we may of course need newer features again in the future, i figure reusing the current input for different purposes could lead to surprising results for end-users. as such, it could be preferable to drop the input until we need disparate versions again.
