### PR TITLE
chore: update 25.05 -> 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,24 +25,26 @@
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
         "rev": "e6f23dc08d3624daab7094b701aa3954923c6bbb",
-        "type": "indirect"
+        "type": "github"
       }
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1761016216,
-        "narHash": "sha256-G/iC4t/9j/52i/nm+0/4ybBmAF4hzR8CNHC75qEhjHo=",
+        "lastModified": 1769318308,
+        "narHash": "sha256-Mjx6p96Pkefks3+aA+72lu1xVehb6mv2yTUUqmSet6Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "481cf557888e05d3128a76f14c76397b7d7cc869",
+        "rev": "1cd347bf3355fce6c64ab37d3967b4a2cb4b878c",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-25.05",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixpkgs-libvncserver.url = "github:NixOS/nixpkgs/e6f23dc08d3624daab7094b701aa3954923c6bbb";
     utils.url = "github:numtide/flake-utils";
     flake-compat.url = "github:edolstra/flake-compat";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -24,6 +24,7 @@ let
     fonts-font-logos = callPackage ./fonts-font-logos { };
     
     markedjs = callPackage ./markedjs { };
+    qrcodejs = callPackage ./qrcodejs { };
     perlmod = callPackage ./perlmod { };
     termproxy = callPackage ./termproxy { };
     unifont_hex = callPackage ./unifont { };

--- a/pkgs/nixmoxer/default.nix
+++ b/pkgs/nixmoxer/default.nix
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication {
   dependencies = with python3Packages; [
     proxmoxer
     click
-    requests_toolbelt
+    requests-toolbelt
   ];
 
   meta = with lib; {

--- a/pkgs/proxmox-backup-qemu/Cargo.lock
+++ b/pkgs/proxmox-backup-qemu/Cargo.lock
@@ -1028,6 +1028,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom 8.0.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1175,12 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1392,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "pbs-api-types"
-version = "1.0.0"
+version = "1.0.9"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1400,8 +1415,10 @@ dependencies = [
  "percent-encoding",
  "proxmox-apt-api-types",
  "proxmox-auth-api",
+ "proxmox-fixed-string",
  "proxmox-human-byte",
  "proxmox-lang",
+ "proxmox-s3-client",
  "proxmox-schema",
  "proxmox-serde",
  "proxmox-time",
@@ -1413,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "pbs-buildcfg"
-version = "3.4.2"
+version = "4.1.1"
 
 [[package]]
 name = "pbs-client"
@@ -1445,6 +1462,7 @@ dependencies = [
  "proxmox-human-byte",
  "proxmox-io",
  "proxmox-log",
+ "proxmox-rate-limiter",
  "proxmox-router",
  "proxmox-schema",
  "proxmox-sys",
@@ -1475,6 +1493,7 @@ dependencies = [
  "pbs-buildcfg",
  "proxmox-notify",
  "proxmox-router",
+ "proxmox-s3-client",
  "proxmox-schema",
  "proxmox-section-config",
  "proxmox-shared-memory",
@@ -1496,6 +1515,8 @@ dependencies = [
  "endian_trait",
  "futures",
  "hex",
+ "http-body-util",
+ "hyper",
  "libc",
  "log",
  "nix 0.29.0",
@@ -1506,12 +1527,16 @@ dependencies = [
  "pbs-config",
  "pbs-key-config",
  "pbs-tools",
+ "proxmox-async",
  "proxmox-base64",
  "proxmox-borrow",
+ "proxmox-http",
  "proxmox-human-byte",
  "proxmox-io",
  "proxmox-lang",
+ "proxmox-s3-client",
  "proxmox-schema",
+ "proxmox-section-config",
  "proxmox-serde",
  "proxmox-sys",
  "proxmox-systemd",
@@ -1695,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-api-macro"
-version = "1.4.0"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "proc-macro2 1.0.106",
@@ -1705,10 +1730,12 @@ dependencies = [
 
 [[package]]
 name = "proxmox-apt-api-types"
-version = "2.0.0"
+version = "2.0.5"
 dependencies = [
  "proxmox-config-digest",
  "proxmox-schema",
+ "proxmox-serde",
+ "regex",
  "serde",
  "serde_plain",
 ]
@@ -1727,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-auth-api"
-version = "1.0.0"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1739,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-backup-qemu"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1781,7 +1808,7 @@ version = "1.1.0"
 
 [[package]]
 name = "proxmox-compression"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1801,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-config-digest"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -1811,8 +1838,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proxmox-fixed-string"
+version = "0.1.1"
+dependencies = [
+ "serde",
+ "serde_plain",
+]
+
+[[package]]
 name = "proxmox-http"
-version = "1.0.0"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1828,6 +1863,7 @@ dependencies = [
  "proxmox-compression",
  "proxmox-io",
  "proxmox-lang",
+ "proxmox-rate-limiter",
  "proxmox-sys",
  "serde_json",
  "sync_wrapper",
@@ -1849,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-human-byte"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "proxmox-schema",
@@ -1859,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-io"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "endian_trait",
  "tokio",
@@ -1886,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-notify"
-version = "1.0.0"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1913,8 +1949,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proxmox-rate-limiter"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "hyper",
+ "nix 0.29.0",
+ "proxmox-shared-memory",
+ "proxmox-sys",
+]
+
+[[package]]
 name = "proxmox-router"
-version = "3.2.2"
+version = "3.2.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1933,12 +1980,46 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "proxmox-s3-client"
+version = "1.2.5"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "const_format",
+ "futures",
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "iso8601",
+ "md5",
+ "nix 0.29.0",
+ "openssl",
+ "proxmox-base64",
+ "proxmox-http",
+ "proxmox-human-byte",
+ "proxmox-rate-limiter",
+ "proxmox-schema",
+ "proxmox-serde",
+ "proxmox-time",
+ "quick-xml",
+ "regex",
+ "serde",
+ "serde-xml-rs",
+ "serde_plain",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "proxmox-schema"
-version = "4.1.0"
+version = "5.0.1"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1951,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-section-config"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -1963,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-sendmail"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "percent-encoding",
@@ -1973,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-serde"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "proxmox-base64",
@@ -2067,6 +2148,16 @@ dependencies = [
  "endian_trait",
  "libc",
  "siphasher",
+ "tokio",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
  "tokio",
 ]
 
@@ -2298,6 +2389,18 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2650,6 +2753,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -3295,6 +3399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,23 +3551,23 @@ version = "0.10.0"
 
 [[patch.unused]]
 name = "proxmox-access-control"
-version = "1.0.0"
+version = "1.3.1"
 
 [[patch.unused]]
 name = "proxmox-acme"
-version = "1.0.0"
+version = "1.0.3"
 
 [[patch.unused]]
 name = "proxmox-acme-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-apt"
-version = "0.99.0"
+version = "0.99.7"
 
 [[patch.unused]]
 name = "proxmox-client"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-daemon"
@@ -3465,15 +3575,15 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-dns-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-ldap"
-version = "1.0.0"
+version = "1.1.0"
 
 [[patch.unused]]
 name = "proxmox-login"
-version = "1.0.1"
+version = "1.0.3"
 
 [[patch.unused]]
 name = "proxmox-metrics"
@@ -3481,11 +3591,23 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-network-api"
+version = "1.0.4"
+
+[[patch.unused]]
+name = "proxmox-network-types"
+version = "0.1.2"
+
+[[patch.unused]]
+name = "proxmox-node-status"
 version = "1.0.0"
 
 [[patch.unused]]
+name = "proxmox-oci"
+version = "0.2.1"
+
+[[patch.unused]]
 name = "proxmox-openid"
-version = "1.0.0"
+version = "1.0.2"
 
 [[patch.unused]]
 name = "proxmox-product-config"
@@ -3493,11 +3615,19 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-resource-scheduling"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-rest-server"
-version = "1.0.0"
+version = "1.0.3"
+
+[[patch.unused]]
+name = "proxmox-rrd"
+version = "1.0.2"
+
+[[patch.unused]]
+name = "proxmox-rrd-api-types"
+version = "1.1.1"
 
 [[patch.unused]]
 name = "proxmox-shared-cache"
@@ -3505,23 +3635,27 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-simple-config"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-subscription"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-syslog-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-tfa"
-version = "6.0.0"
+version = "6.0.4"
 
 [[patch.unused]]
 name = "proxmox-time-api"
-version = "1.0.0"
+version = "1.0.1"
+
+[[patch.unused]]
+name = "proxmox-upgrade-checks"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-ve-config"

--- a/pkgs/proxmox-backup-qemu/Cargo.lock
+++ b/pkgs/proxmox-backup-qemu/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -67,22 +67,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -93,9 +93,9 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
  "object",
 ]
@@ -106,9 +106,9 @@ version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -131,9 +131,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -161,15 +161,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cbindgen"
@@ -181,20 +181,20 @@ dependencies = [
  "heck 0.4.1",
  "indexmap",
  "log",
- "proc-macro2 1.0.103",
- "quote 1.0.41",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
  "serde",
  "serde_json",
- "syn 2.0.108",
+ "syn 2.0.114",
  "tempfile",
  "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.43"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -232,18 +232,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.50"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
+checksum = "3e34525d5bbbd55da2bb745d34b36121baac88d07619a9a09cfcf4a6c0832785"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.50"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
+checksum = "59a20016a20a3da95bef50ec7238dbd09baeef4311dcdd38ec15aba69812fb61"
 dependencies = [
  "anstream",
  "anstyle",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "clipboard-win"
@@ -287,8 +287,8 @@ version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
  "unicode-xid 0.2.6",
 ]
 
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -368,9 +368,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -421,9 +421,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -462,7 +462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -490,27 +490,26 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -600,9 +599,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -637,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -647,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -670,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -713,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -785,32 +784,31 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "hostname"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -851,9 +849,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -874,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -887,7 +885,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -895,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -908,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -921,11 +919,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -936,42 +933,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1002,12 +995,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1036,32 +1029,32 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1076,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1110,26 +1103,26 @@ dependencies = [
  "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -1146,9 +1139,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -1161,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-cache"
@@ -1213,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -1298,14 +1291,14 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1324,9 +1317,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.74"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1343,9 +1336,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1356,9 +1349,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.110"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -1384,9 +1377,9 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1590,9 +1583,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.3"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
+checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1600,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.3"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
+checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1610,22 +1603,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.3"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
+checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.3"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
+checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
  "sha2",
@@ -1651,9 +1644,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1666,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -1693,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1705,9 +1698,9 @@ name = "proxmox-api-macro"
 version = "1.4.0"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2003,9 +1996,9 @@ dependencies = [
 name = "proxmox-sortable-macro"
 version = "1.0.0"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2059,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
+checksum = "1fa96cb91275ed31d6da3e983447320c4eb219ac180fa1679a0889ff32861e2d"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -2088,11 +2081,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
- "proc-macro2 1.0.103",
+ "proc-macro2 1.0.106",
 ]
 
 [[package]]
@@ -2144,7 +2137,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2152,6 +2145,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
 ]
@@ -2187,37 +2189,28 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
@@ -2249,12 +2242,6 @@ dependencies = [
  "utf8parse",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -2328,22 +2315,22 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2392,24 +2379,25 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -2441,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -2487,12 +2475,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
  "unicode-ident",
 ]
 
@@ -2511,9 +2499,9 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2529,15 +2517,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2566,9 +2554,9 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2582,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2607,16 +2595,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2627,9 +2615,9 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2645,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2656,9 +2644,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2716,9 +2704,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2727,20 +2715,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2748,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-journald"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0b4143302cf1022dac868d521e36e8b27691f72c84b3311750d5188ebba657"
+checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
 dependencies = [
  "libc",
  "tracing-core",
@@ -2770,9 +2758,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -2802,9 +2790,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2844,16 +2832,15 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "ureq"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ba1025f18a4a3fc3e9b48c868e9beb4f24f4b4b1a325bada26bd4119f46537"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
 dependencies = [
  "base64",
  "der",
  "log",
  "native-tls",
  "percent-encoding",
- "rustls-pemfile",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
@@ -2862,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64",
  "http",
@@ -2874,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2947,18 +2934,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2969,41 +2956,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
- "quote 1.0.41",
+ "quote 1.0.44",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d651ec480de84b762e7be71e6efa7461699c19d9e2c272c8d93455f567786e"
+checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3020,14 +3007,8 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -3077,7 +3058,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3117,7 +3098,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -3268,9 +3249,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -3287,15 +3268,15 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xattr"
@@ -3315,11 +3296,10 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -3327,34 +3307,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3372,9 +3352,9 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -3386,9 +3366,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3397,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3408,14 +3388,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
 
 [[package]]
 name = "zstd"

--- a/pkgs/proxmox-backup-qemu/default.nix
+++ b/pkgs/proxmox-backup-qemu/default.nix
@@ -25,12 +25,12 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "proxmox-backup-qemu";
-  version = "2.0.1";
+  version = "2.0.2";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/${pname}.git";
-    rev = "2b8ebba0cffecd479f296aaad82d8bec89355599";
-    hash = "sha256-GLd/zNNZXaCKm1K8gSQ07m/7jn0XGC9gW51VLWEODkA=";
+    rev = "594183eab9fa275f45dfff5dd15b16f150abd503";
+    hash = "sha256-YjP4TI/MoobK1RAdaDS3MO91DXsS55OFv9dpdXSkZmU=";
     fetchSubmodules = true;
   };
 
@@ -79,10 +79,6 @@ rustPlatform.buildRustPackage rec {
   '';
 
   LIBCLANG_PATH = "${libclang.lib}/lib";
-
-  # Allow deprecated raw pointer dereference pattern until pbs-api-types gets fixed upstream
-  # This is needed for Rust 1.91+ which denies dangerous_implicit_autorefs by default
-  RUSTFLAGS = "-A dangerous_implicit_autorefs";
 
   cargoTestExtraArgs = "-- --skip=test_get_current_release_codename rrd::tests::load_and_save_rrd_v2 rrd::tests::upgrade_from_rrd_v1";
 }

--- a/pkgs/proxmox-backup-qemu/default.nix
+++ b/pkgs/proxmox-backup-qemu/default.nix
@@ -80,5 +80,9 @@ rustPlatform.buildRustPackage rec {
 
   LIBCLANG_PATH = "${libclang.lib}/lib";
 
+  # Allow deprecated raw pointer dereference pattern until pbs-api-types gets fixed upstream
+  # This is needed for Rust 1.91+ which denies dangerous_implicit_autorefs by default
+  RUSTFLAGS = "-A dangerous_implicit_autorefs";
+
   cargoTestExtraArgs = "-- --skip=test_get_current_release_codename rrd::tests::load_and_save_rrd_v2 rrd::tests::upgrade_from_rrd_v1";
 }

--- a/pkgs/proxmox-backup-qemu/sources.nix
+++ b/pkgs/proxmox-backup-qemu/sources.nix
@@ -13,19 +13,6 @@
     ];
   }
   {
-    name = "librust-pbs-api-types-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "956cd368bb7c80740bcc6f2f50fa70de26e6d788";
-
-    sha256 = "0mims8ij7y7gywvipz6159x3if6ybp4ghacrxaly2knk3g5d8c49";
-    crates = [
-      {
-        name = "pbs-api-types";
-        path = "pbs-api-types";
-      }
-    ];
-  }
-  {
     name = "librust-perlmod-dev";
     url = "git://git.proxmox.com/git/perlmod.git";
     rev = "3f0fcc1f1601bad6ccacd38796865a927d100cda";
@@ -52,37 +39,24 @@
     ];
   }
   {
-    name = "librust-proxmox-access-control-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "160506ea3884d5c38fee29d11dd03a352348d6ad";
+    name = "librust-proxmox-ve-config-dev";
+    url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
+    rev = "fcfed30d860966320753752e33853981362d616e";
 
-    sha256 = "1yl3xhwd8klzrzyr9nbll9sa3b8c4nnbhxcndghqbria5lqjibv1";
+    sha256 = "0gvwkyz2s8111rymg7ccqrfhx652y3y6i2bq1xys0yg2myy913zw";
     crates = [
       {
-        name = "proxmox-access-control";
-        path = "proxmox-access-control";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-acme-api-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "beaadf89ea2b0de080ea99c52cbef04753498a06";
-
-    sha256 = "01v9w2xcc1dijsdgngcngicjjrbm5irc9z011ap8mw37rkfdq7iz";
-    crates = [
-      {
-        name = "proxmox-acme-api";
-        path = "proxmox-acme-api";
+        name = "proxmox-ve-config";
+        path = "proxmox-ve-config";
       }
     ];
   }
   {
     name = "librust-proxmox-acme-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "6b4de64dc5618611e2616e3357fbf386de7a02f0";
+    rev = "039d25dfcfb53b60c641b46fd471c45acc2811e0";
 
-    sha256 = "1qfc8f6gij17z6k0wc5vaarrycfsjkhxrwz3ay6skfmnj1z635ck";
+    sha256 = "00c3mjd223r6x0a8jzdz3j6qrrdixq8r5qyngn4nds1rg0k9vhxw";
     crates = [
       {
         name = "proxmox-acme";
@@ -91,115 +65,11 @@
     ];
   }
   {
-    name = "librust-proxmox-api-macro-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3f59c3f3815bccc8485b7e76051ef5cc61cb363a";
-
-    sha256 = "1hl4b1zqrj0kjgzpkqkk0y0y58j2zrr8c8v0xbrpl4lw64d0jdl1";
-    crates = [
-      {
-        name = "proxmox-api-macro";
-        path = "proxmox-api-macro";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-apt-api-types-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "e2305b8f8e610e713b5acb9d90f42a1423abf1d8";
-
-    sha256 = "09ywa6fkk7x10sa3234p3zkbjvsj404a0pqwbq59f1pkn5sd3b59";
-    crates = [
-      {
-        name = "proxmox-apt-api-types";
-        path = "proxmox-apt-api-types";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-apt-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "80f76ec62fde055f522f0a356353ec491d9854ce";
-
-    sha256 = "0izwnap5slyrkdisrczd6g5knajmd45cjin54n93c12jfqdzka8y";
-    crates = [
-      {
-        name = "proxmox-apt";
-        path = "proxmox-apt";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-async-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "9820e1ca7694c505b3cb9711f124026e0bb7ea4a";
-
-    sha256 = "0inf0iqs8hhz4xanvin0131f8a7ypk4yvfbl3brg6gf2rn6p6rhr";
-    crates = [
-      {
-        name = "proxmox-async";
-        path = "proxmox-async";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-auth-api-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "125cc32b777bde7e9f6691917b2de7ed8dac5dc5";
-
-    sha256 = "0v1ik5rggdif82bj7rkq6bzi1gq7755xk95ys32cja418yakbkr2";
-    crates = [
-      {
-        name = "proxmox-auth-api";
-        path = "proxmox-auth-api";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-base64-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "a5015e9684f62f7dc4f28111dec8971dd33a40d4";
-
-    sha256 = "0c3f1dcsh5zz9gq91a1772zxg16vfxpvjnpj0xzkkhl4k57dbryr";
-    crates = [
-      {
-        name = "proxmox-base64";
-        path = "proxmox-base64";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-borrow-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "82beb937ad4308848cb50ab619320d3b553060f9";
-
-    sha256 = "1929f28nc5w0asigvrm44wa5i93wmkhyf4zbj754k5xzr14qg8cg";
-    crates = [
-      {
-        name = "proxmox-borrow";
-        path = "proxmox-borrow";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-client-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "2b21ed67474ac26b57964354445b2b39bdbf4157";
-
-    sha256 = "0ajm4mdxq35rx13vadm3mq6l935nkyvnl5iq6gy4kykr1j718phq";
-    crates = [
-      {
-        name = "proxmox-client";
-        path = "proxmox-client";
-      }
-    ];
-  }
-  {
     name = "librust-proxmox-compression-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "47719bb5836d23cfebd7904e95e5bf6770d6db4f";
+    rev = "07aad061ee24502b2bdb4695c1e594b00818d90f";
 
-    sha256 = "1ryd3h7nxa7gia9z52ia985gia1dyvhclsjdh4adiyrikbgzccsz";
+    sha256 = "04cbc75bcib1imknw0cmva9awz73nay3mx73vd8msni5q6xdkrn4";
     crates = [
       {
         name = "proxmox-compression";
@@ -208,93 +78,15 @@
     ];
   }
   {
-    name = "librust-proxmox-config-digest-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "04fa1610da66aa4a3782a28f7d79c1043d4b42ed";
-
-    sha256 = "0nxpm806civ5qx33h1r8qdi6hcxr656pr52d6c3n5ymgknx1h3aj";
-    crates = [
-      {
-        name = "proxmox-config-digest";
-        path = "proxmox-config-digest";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-daemon-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "de88fc9a481042a1d10164687515f5496c13a762";
-
-    sha256 = "1m0rkarpmk2yxl2xkc04adxj4fnz39s09kcqgbd081jh6sv90vq3";
-    crates = [
-      {
-        name = "proxmox-daemon";
-        path = "proxmox-daemon";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-dns-api-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "4ea106bee233a996afbc1ce2dff6179f4f13433a";
-
-    sha256 = "08srksgqpx1lqx99npk40imd9s70bms4p3k445h8byxr6znb5rxn";
-    crates = [
-      {
-        name = "proxmox-dns-api";
-        path = "proxmox-dns-api";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-http-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "fe85188161d20c638d3e96aa784beac65faaa822";
-
-    sha256 = "0ykk42my3f28i7dbda2zhw0w5df79q2db6xbvk4g10yjp4wrg7rn";
-    crates = [
-      {
-        name = "proxmox-http";
-        path = "proxmox-http";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-http-error-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "c54d689db2328803d1c7944311e55bc83805a1fa";
-
-    sha256 = "1q39jkgjbn4cd7crvdinpx3z60zz53xyk0rfv10vkp0h46xd8da8";
-    crates = [
-      {
-        name = "proxmox-http-error";
-        path = "proxmox-http-error";
-      }
-    ];
-  }
-  {
     name = "librust-proxmox-human-byte-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "000432028d39633918cc9ae9ced55b5dc5141564";
+    rev = "07e146b60c147bdfc7a4a1f07f044808078fc4a0";
 
-    sha256 = "0wsc0srrfkaljbb7gb8k0d2p1shrg5zpx415545y2sfc40a50fvm";
+    sha256 = "0dd09x76fffdijgqp4pcdy9s5hvir2xfkz30hgxh6wz56dj0pxlq";
     crates = [
       {
         name = "proxmox-human-byte";
         path = "proxmox-human-byte";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-io-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "b04e04b13d835b64abd30e1baf5974023cfcc370";
-
-    sha256 = "1dqi3aqp91ks5np9k4m70s05x57p7jnx63hlsy7871vs7yqvf7f3";
-    crates = [
-      {
-        name = "proxmox-io";
-        path = "proxmox-io";
       }
     ];
   }
@@ -312,180 +104,24 @@
     ];
   }
   {
-    name = "librust-proxmox-ldap-dev";
+    name = "librust-proxmox-rrd-api-types-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3ccba3065a9165ae949eabbd5a3ae08cf018cef7";
+    rev = "11cbf7e700f1d8dcfd70eebb071ef33f9f8bd58c";
 
-    sha256 = "0gz43z36j89mkidsri0hw75y9l244pcf5lbamq44s6d8gdsniz4m";
+    sha256 = "1h18qy0p38mbgvkvsbdpbq0ks5d42mghkj124l84f9dwq0ma288m";
     crates = [
       {
-        name = "proxmox-ldap";
-        path = "proxmox-ldap";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-log-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "4a70ad566609a893451220b2ba0d4451a893e93e";
-
-    sha256 = "17sqf08w4qr3i0zpi5psfwlyv7vaxwj7kfa9ibfs0i1sqpzk3cvb";
-    crates = [
-      {
-        name = "proxmox-log";
-        path = "proxmox-log";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-login-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "d22a98772c2cea7c49d469255ae1ed2060a10e7d";
-
-    sha256 = "1h8w4xbappq9cvjcgnmfra4snfs2l6323y5bzr7cvz4xi4wfx269";
-    crates = [
-      {
-        name = "proxmox-login";
-        path = "proxmox-login";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-metrics-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "c6830856f5558b5a812f47d659e817a5543c7976";
-
-    sha256 = "0790rzjf12i07i7kiphc3llzj206hbq9argjp6bl1019hxf28ywh";
-    crates = [
-      {
-        name = "proxmox-metrics";
-        path = "proxmox-metrics";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-network-api-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "0d7cde29e7502082fce836362b1dffa217b99cbb";
-
-    sha256 = "18g8wi47jbbzv5vqi6hay27g01w07ai5lbi7smb6cf92n5g01w3b";
-    crates = [
-      {
-        name = "proxmox-network-api";
-        path = "proxmox-network-api";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-notify-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "a73841292a19b7ceb0318a9092ee1b7cac4c7006";
-
-    sha256 = "0h3mamnpprqkgn8bjb82pbi89hxknbxp0qcyv83hqk774svm77ix";
-    crates = [
-      {
-        name = "proxmox-notify";
-        path = "proxmox-notify";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-openid-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "2dcdb435ec4b123dbca5f3d81886174c4c831989";
-
-    sha256 = "1i8408pzh5ldgimrv4fnndjlpbdwpnamx8mif94hwmxdkwi72s2n";
-    crates = [
-      {
-        name = "proxmox-openid";
-        path = "proxmox-openid";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-product-config-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "d42d5038bc4998200d18c9d190b9b013d6522722";
-
-    sha256 = "1dsjziab9d8lm34fdd4fh2rjm6xz3fas6rwaya0gzc8dwmvn4ar2";
-    crates = [
-      {
-        name = "proxmox-product-config";
-        path = "proxmox-product-config";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-resource-scheduling-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "5625354accdede10680287257d959e135b6742d0";
-
-    sha256 = "02bh82r3yccvgydvpi23k8nh0r2wn3503ji0z35fl5npb7ayzvsk";
-    crates = [
-      {
-        name = "proxmox-resource-scheduling";
-        path = "proxmox-resource-scheduling";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-rest-server-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "9dd397f84e23f1eb87046ff394fdf3df824376ea";
-
-    sha256 = "0h2wrg5955rih2441s4vlb7bcyscxc34va2d1i4ik8j616pxli0p";
-    crates = [
-      {
-        name = "proxmox-rest-server";
-        path = "proxmox-rest-server";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-router-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "35c28da99fc02a8f9de3e010ccac3dc8167e8c31";
-
-    sha256 = "1a51xxz9l5gs02dyxhx1zcc1733j543n04xnx5557cxbyfcj5d9h";
-    crates = [
-      {
-        name = "proxmox-router";
-        path = "proxmox-router";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-schema-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "997bcc2f9d96f2e9835673f3a80846d60a908aed";
-
-    sha256 = "1ldkh7z1lja4qzni2kwc2dbr0gm7cd0lcq9brxlq5i932rwvcpvv";
-    crates = [
-      {
-        name = "proxmox-schema";
-        path = "proxmox-schema";
-      }
-    ];
-  }
-  {
-    name = "librust-proxmox-section-config-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "61b5788a639e3e74f85666f8c240d6b37acdf9fa";
-
-    sha256 = "0w8zggdf9dcfbk8f11ipq50z0id9fab0jadsrjn8vw1w5gh5rwf9";
-    crates = [
-      {
-        name = "proxmox-section-config";
-        path = "proxmox-section-config";
+        name = "proxmox-rrd-api-types";
+        path = "proxmox-rrd-api-types";
       }
     ];
   }
   {
     name = "librust-proxmox-sendmail-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "f03e6651032acce45246f49a6bc6bc1f0794244b";
+    rev = "13340ae4452f8e07d2b35769233914ab8cb84192";
 
-    sha256 = "098px04lajing8pypax7lqardafdzsm9ikpg8qdcwx7p1qhsnjvy";
+    sha256 = "1yafbqafwv7bjgc414p6vm6hiy0fwb53sh9wsp2l3m83i5ixx464";
     crates = [
       {
         name = "proxmox-sendmail";
@@ -494,50 +130,76 @@
     ];
   }
   {
-    name = "librust-proxmox-serde-dev";
+    name = "librust-proxmox-apt-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "521ebf5bf0160f7a8843d363073ebb9e21d101c1";
+    rev = "1ed1c4244f68ac9f1e0d98cb1c9be47ec3a8b492";
 
-    sha256 = "0mwsdg7j6xa1nlvgnqqlpw49vazs399f2m3c4g5p08hx39wvlhzv";
+    sha256 = "1ars6m6j2axmaz0as0ifcx6vvqv2nvjd6kgjajgwvc8qaxfakars";
     crates = [
       {
-        name = "proxmox-serde";
-        path = "proxmox-serde";
+        name = "proxmox-apt";
+        path = "proxmox-apt";
       }
     ];
   }
   {
-    name = "librust-proxmox-shared-cache-dev";
+    name = "librust-proxmox-acme-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "d23c49fe82b9bd7a15c7c58585be443116f3045a";
+    rev = "2383831533bf316ce0dea93205cd263c101452e9";
 
-    sha256 = "151czqr9v08vqp2jfgdbc79fbq5v7jpyhifzn244zrvmklpgsmiv";
+    sha256 = "00r7wmcl7fk900939cjc2dmnj2bbv8wjp19gdr500dali1v7mxk9";
     crates = [
       {
-        name = "proxmox-shared-cache";
-        path = "proxmox-shared-cache";
+        name = "proxmox-acme-api";
+        path = "proxmox-acme-api";
       }
     ];
   }
   {
-    name = "librust-proxmox-shared-memory-dev";
+    name = "librust-proxmox-auth-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "eb1116c1e3fd27e391a9dde487eabc673368a6c5";
+    rev = "24536125a427eeca1180b9e37e86482e872393ee";
 
-    sha256 = "0gccrgy2qlggqwhb42zkypn8bdg05xxd62g4gaz9mzc1wby9bk34";
+    sha256 = "06i3lr9yna72xngj8zrkicvn3lfhh73lyqr0ij2qni542d5vim8f";
     crates = [
       {
-        name = "proxmox-shared-memory";
-        path = "proxmox-shared-memory";
+        name = "proxmox-auth-api";
+        path = "proxmox-auth-api";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-section-config-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "2a375fa97ea361fb7b2c283b754478a1a6e791c7";
+
+    sha256 = "1f3rlcf8w0zfdn3znah79k3f55rqjvrg2k0w02klsr7knqv8s050";
+    crates = [
+      {
+        name = "proxmox-section-config";
+        path = "proxmox-section-config";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-tfa-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "320f2f0c600b03829bfe534ea4bed4730122dad0";
+
+    sha256 = "01dnv4jcagpv8vkajm98l1bml3z8w5sj2p214y94l4915j7991xm";
+    crates = [
+      {
+        name = "proxmox-tfa";
+        path = "proxmox-tfa";
       }
     ];
   }
   {
     name = "librust-proxmox-simple-config-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "c273e86e0cef266e11ccfe2d2522e79173ffdaff";
+    rev = "35587a12af4197fb8243c9239a27302d2fc283b8";
 
-    sha256 = "1zma7rj7ksl0n5msnwbi195kkxchj3ax9h5fg3q8v5v70dmv8vv9";
+    sha256 = "1f81702jxdi9mxbrix4fsq71aw5nmj41myi6y45cimx1lm49gpdg";
     crates = [
       {
         name = "proxmox-simple-config";
@@ -546,28 +208,28 @@
     ];
   }
   {
-    name = "librust-proxmox-sortable-macro-dev";
+    name = "librust-proxmox-time-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "a1766995b589c5668a7f9d4f0b15e6fbe32b6a36";
+    rev = "3db314886689109607ff9756fff04c4710e2c410";
 
-    sha256 = "1p1q732ni8cmx3hckac01q93y1bq2qrpr0zgigwq095gg6xik680";
+    sha256 = "072f7b3pabkkhf7v349n2ns99xhqlamzs7wvhipgbz354rv62q42";
     crates = [
       {
-        name = "proxmox-sortable-macro";
-        path = "proxmox-sortable-macro";
+        name = "proxmox-time-api";
+        path = "proxmox-time-api";
       }
     ];
   }
   {
-    name = "librust-proxmox-subscription-dev";
+    name = "librust-proxmox-s3-client-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "5f641e5a99e89d52ccdde500d79ce2c0d6dea71a";
+    rev = "442d8e18030bf05b83d1e2f6ae86fd6153f0235c";
 
-    sha256 = "1s249m4z776czzbhi0s4a8vshh2p7pw305iqxfsjnk06ii6zghnf";
+    sha256 = "125zwps2p0cyag3h7bcch6s647ivbf2pl67gz68lw96z45i3x3xr";
     crates = [
       {
-        name = "proxmox-subscription";
-        path = "proxmox-subscription";
+        name = "proxmox-s3-client";
+        path = "proxmox-s3-client";
       }
     ];
   }
@@ -585,11 +247,141 @@
     ];
   }
   {
+    name = "librust-proxmox-log-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "4a70ad566609a893451220b2ba0d4451a893e93e";
+
+    sha256 = "17sqf08w4qr3i0zpi5psfwlyv7vaxwj7kfa9ibfs0i1sqpzk3cvb";
+    crates = [
+      {
+        name = "proxmox-log";
+        path = "proxmox-log";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-api-macro-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "4defc51c0d5b35d5c503338fe79755436ccfb0e6";
+
+    sha256 = "1xv198sn5i3k16f9k7irmnyjqz9jjl1n1w1flhjg3r938q17qna7";
+    crates = [
+      {
+        name = "proxmox-api-macro";
+        path = "proxmox-api-macro";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-login-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "4eb5517830ae58ca522bfe9f90abac1753579889";
+
+    sha256 = "1y44rivch5zci1501nazyldy7qkf1n547245y2yy6ikah7s04x9j";
+    crates = [
+      {
+        name = "proxmox-login";
+        path = "proxmox-login";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-notify-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "52b04982627911d4d7255bd25c78d7eb4d695bcf";
+
+    sha256 = "1xaamw59agm1dcphz2hpl46x8xpavl8vjjnjzrkqzm67vh3zrshp";
+    crates = [
+      {
+        name = "proxmox-notify";
+        path = "proxmox-notify";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-network-api-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "55ecc70c85986dd7d692a42284a96f977ff732b6";
+
+    sha256 = "10j35q04ma464glxlmh7pvlnk1ysnk71kvda4k9a5hvd4sfmns36";
+    crates = [
+      {
+        name = "proxmox-network-api";
+        path = "proxmox-network-api";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-oci-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "56e0f959d8d906d169b1302920e96ca644692628";
+
+    sha256 = "0k8pywhnnpz67k9qaks68g57pdrn5vzw9aabzrni4ph435zarq72";
+    crates = [
+      {
+        name = "proxmox-oci";
+        path = "proxmox-oci";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-apt-api-types-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "617c37f6c07017892488c9a553ec60a9d77aeb1c";
+
+    sha256 = "0kzv1frwrbhilhrszfalxcha9m0b0kv0zc1v9zlhh99m4wybkpgl";
+    crates = [
+      {
+        name = "proxmox-apt-api-types";
+        path = "proxmox-apt-api-types";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-resource-scheduling-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "69d1fddb642a2a102095cfa10e41ef10abc8a5e6";
+
+    sha256 = "1ag2j6rb89321wps1isxjnyj8hr45hxrgx1jh84k19kj8322vrfb";
+    crates = [
+      {
+        name = "proxmox-resource-scheduling";
+        path = "proxmox-resource-scheduling";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-access-control-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "6a8354f4b3af0c0f8988e4cfc2b8f6554182e6fc";
+
+    sha256 = "0jd8rdb6rh7ji4dkdg0d09ihlacwnz5sa4kaqmgdq632f12s43m5";
+    crates = [
+      {
+        name = "proxmox-access-control";
+        path = "proxmox-access-control";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-config-digest-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "6d1bdcbb38fb0358495f404e8cad38231498f1bf";
+
+    sha256 = "05q2vff5z7ms8vv14l1z690gncmapjc5wxffzsq4vfd2cpbg4ig6";
+    crates = [
+      {
+        name = "proxmox-config-digest";
+        path = "proxmox-config-digest";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-syslog-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "b79913168ac606619b4934a614dcfc83cc6833ee";
+    rev = "7440ea15b3a70fe4b00a4986957dfd031053ac14";
 
-    sha256 = "1q3z4csi2l2m1bppk9rv7hmf9mlwsvfa7a7c3iil0c9ws3767x0d";
+    sha256 = "08ysn6z0cfcic9w0xcpm9a590ry4dd60n3gs2c9nj5n81gz06rr8";
     crates = [
       {
         name = "proxmox-syslog-api";
@@ -598,41 +390,145 @@
     ];
   }
   {
-    name = "librust-proxmox-systemd-dev";
+    name = "librust-proxmox-rate-limiter-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "fb3e8ca768c5c815fc55ca78e095df35a1c06d78";
+    rev = "7612fe31b021b241aab7ae2beb999ea10d2e0bcb";
 
-    sha256 = "1lblv6sw4rrwf1xha3hz727mwas90zqykx9nwrw60s0sabw5pyic";
+    sha256 = "0ibch53yiwiqsgnaay3mjkci2mg4ar0yr1wq5a538pzsfw4gag2s";
     crates = [
       {
-        name = "proxmox-systemd";
-        path = "proxmox-systemd";
+        name = "proxmox-rate-limiter";
+        path = "proxmox-rate-limiter";
       }
     ];
   }
   {
-    name = "librust-proxmox-tfa-dev";
+    name = "librust-proxmox-subscription-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3ee2c779f44d60b9698031f1869dd6f9fe984659";
+    rev = "7c2a07e69b42b73e149489027409932af623ef94";
 
-    sha256 = "1xbq98ccjmd10cjl7v7hnhp9q8gjvzja0hzncmwhahna6agd5708";
+    sha256 = "1mkm2wvpr7nn03b9f2kxlylwi2sf8nyynk3kjy10aam8x1kdnxa7";
     crates = [
       {
-        name = "proxmox-tfa";
-        path = "proxmox-tfa";
+        name = "proxmox-subscription";
+        path = "proxmox-subscription";
       }
     ];
   }
   {
-    name = "librust-proxmox-time-api-dev";
+    name = "librust-proxmox-borrow-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3d8d38799e403e069679aa942565d95bc65b48fe";
+    rev = "82beb937ad4308848cb50ab619320d3b553060f9";
 
-    sha256 = "0ga8zp7kqvlzvjal9zgwi4qx7nj0grjg0a9xb9ll6anx08si0jac";
+    sha256 = "1929f28nc5w0asigvrm44wa5i93wmkhyf4zbj754k5xzr14qg8cg";
     crates = [
       {
-        name = "proxmox-time-api";
-        path = "proxmox-time-api";
+        name = "proxmox-borrow";
+        path = "proxmox-borrow";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-serde-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "84ee8f4e5d825625a3d957b341f5c55cca1e4b32";
+
+    sha256 = "06ygg8j5h466k0hvbbf0323abjcv7j72qxn2vkvfxxb7dygagwsd";
+    crates = [
+      {
+        name = "proxmox-serde";
+        path = "proxmox-serde";
+      }
+    ];
+  }
+  {
+    name = "librust-pbs-api-types-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "8c73b19ca906981be2227ba41b303e819ff59fc5";
+
+    sha256 = "00byp3dgshwfa47c4mq210r5vlqkylpyk02dlwhjns70k671mfl9";
+    crates = [
+      {
+        name = "pbs-api-types";
+        path = "pbs-api-types";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-upgrade-checks-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "8d74e99aed319f6cb56161d22804206da96b602d";
+
+    sha256 = "06zagxhbap49c4sbavj1qbwnaggcjx6l9fvygnlys3qjryq2hmbm";
+    crates = [
+      {
+        name = "proxmox-upgrade-checks";
+        path = "proxmox-upgrade-checks";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-async-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "9820e1ca7694c505b3cb9711f124026e0bb7ea4a";
+
+    sha256 = "0inf0iqs8hhz4xanvin0131f8a7ypk4yvfbl3brg6gf2rn6p6rhr";
+    crates = [
+      {
+        name = "proxmox-async";
+        path = "proxmox-async";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-router-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "99c6d274aa41dd09d49bf9b6947df05c209ca8f9";
+
+    sha256 = "0h9qhi6gc1gjm8i2w2faahw91y6aagnian54scp0mh1mwi195dry";
+    crates = [
+      {
+        name = "proxmox-router";
+        path = "proxmox-router";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-rest-server-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "9c04287c6a38fb00e85aa00935279e8aeb68c993";
+
+    sha256 = "0daip10frbg79ks453qlrj197lhg2j5351yrc2mg5jgn2jh79z3r";
+    crates = [
+      {
+        name = "proxmox-rest-server";
+        path = "proxmox-rest-server";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-sortable-macro-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "a1766995b589c5668a7f9d4f0b15e6fbe32b6a36";
+
+    sha256 = "1p1q732ni8cmx3hckac01q93y1bq2qrpr0zgigwq095gg6xik680";
+    crates = [
+      {
+        name = "proxmox-sortable-macro";
+        path = "proxmox-sortable-macro";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-base64-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "a5015e9684f62f7dc4f28111dec8971dd33a40d4";
+
+    sha256 = "0c3f1dcsh5zz9gq91a1772zxg16vfxpvjnpj0xzkkhl4k57dbryr";
+    crates = [
+      {
+        name = "proxmox-base64";
+        path = "proxmox-base64";
       }
     ];
   }
@@ -654,7 +550,7 @@
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "391412712c4dd6f86157eb0c3767ef6e36750896";
 
-    sha256 = "sha256-c3Z7LveHM34DNlEcVpFFgP8sQFIDYjPsxO6wdK2RdgE=";
+    sha256 = "00bnj6np9c7fqkn36qh3a902rzw08n8mc72i6q1pwcw7ywp7nxkk";
     crates = [
       {
         name = "proxmox-uuid";
@@ -663,15 +559,54 @@
     ];
   }
   {
-    name = "librust-proxmox-ve-config-dev";
-    url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
-    rev = "fcfed30d860966320753752e33853981362d616e";
+    name = "librust-proxmox-dns-api-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "ad022fe03631d74be151e91ececb9698c55465a8";
 
-    sha256 = "0gvwkyz2s8111rymg7ccqrfhx652y3y6i2bq1xys0yg2myy913zw";
+    sha256 = "0bdwrkadk26vb9c14qrmkkcil5ddq8vyhb3wpm1isxax0fwkhbh2";
     crates = [
       {
-        name = "proxmox-ve-config";
-        path = "proxmox-ve-config";
+        name = "proxmox-dns-api";
+        path = "proxmox-dns-api";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-http-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "adb44f2e032755b227b95c089c1d64c026809e18";
+
+    sha256 = "08bn1j9xvkmj9k1js85wrgj535fp8f29drx574ldlhsdgmicnpd8";
+    crates = [
+      {
+        name = "proxmox-http";
+        path = "proxmox-http";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-network-types-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "b2e044225ba078a892e80405f424f25f9518417b";
+
+    sha256 = "1mm6lfnrji5gxlsa591gswcjdn5wh3g48f84d7n6lh42g5ibb3ks";
+    crates = [
+      {
+        name = "proxmox-network-types";
+        path = "proxmox-network-types";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-rrd-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "b4aade2a20e12326d2a239279cbc12d12cc50a43";
+
+    sha256 = "097d8y67knzpcw3x5dw0ld6a46557kys9sjkgi2csqkzl8j4ypnl";
+    crates = [
+      {
+        name = "proxmox-rrd";
+        path = "proxmox-rrd";
       }
     ];
   }
@@ -689,11 +624,193 @@
     ];
   }
   {
+    name = "librust-proxmox-io-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "bb3016b84666f707899c36b679c145902510ea1f";
+
+    sha256 = "1wyn07lbbjxhxv9367gg784jr881jmsdnz1rig9abfhj2p2dn28i";
+    crates = [
+      {
+        name = "proxmox-io";
+        path = "proxmox-io";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-ldap-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "c13754571eb37e157fa5dc9d21651dc29827459d";
+
+    sha256 = "03cv9sgxcxmrlk4h4mb072aq4ds44pds07hlh72lrbrp4kjaa7nh";
+    crates = [
+      {
+        name = "proxmox-ldap";
+        path = "proxmox-ldap";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-http-error-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "c54d689db2328803d1c7944311e55bc83805a1fa";
+
+    sha256 = "1q39jkgjbn4cd7crvdinpx3z60zz53xyk0rfv10vkp0h46xd8da8";
+    crates = [
+      {
+        name = "proxmox-http-error";
+        path = "proxmox-http-error";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-metrics-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "c6830856f5558b5a812f47d659e817a5543c7976";
+
+    sha256 = "0790rzjf12i07i7kiphc3llzj206hbq9argjp6bl1019hxf28ywh";
+    crates = [
+      {
+        name = "proxmox-metrics";
+        path = "proxmox-metrics";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-openid-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "cddc6b525b92cea57694297fba678d49e348ba8a";
+
+    sha256 = "1wkrs2xid9wfzv4i9r0kpcdrxhr8rhlp5hwyzbjvm2vi50h0d0jl";
+    crates = [
+      {
+        name = "proxmox-openid";
+        path = "proxmox-openid";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-shared-cache-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "d23c49fe82b9bd7a15c7c58585be443116f3045a";
+
+    sha256 = "151czqr9v08vqp2jfgdbc79fbq5v7jpyhifzn244zrvmklpgsmiv";
+    crates = [
+      {
+        name = "proxmox-shared-cache";
+        path = "proxmox-shared-cache";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-product-config-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "d42d5038bc4998200d18c9d190b9b013d6522722";
+
+    sha256 = "1dsjziab9d8lm34fdd4fh2rjm6xz3fas6rwaya0gzc8dwmvn4ar2";
+    crates = [
+      {
+        name = "proxmox-product-config";
+        path = "proxmox-product-config";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-daemon-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "de88fc9a481042a1d10164687515f5496c13a762";
+
+    sha256 = "1m0rkarpmk2yxl2xkc04adxj4fnz39s09kcqgbd081jh6sv90vq3";
+    crates = [
+      {
+        name = "proxmox-daemon";
+        path = "proxmox-daemon";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-fixed-string-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "e53a6814c3b5e98ed546489c396a14572a680f0f";
+
+    sha256 = "0nf6jmc8f8z42g4gi2q384nm3p9h1nr3syjknf08lph05x0m65ia";
+    crates = [
+      {
+        name = "proxmox-fixed-string";
+        path = "proxmox-fixed-string";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-client-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "e60a1caef6ba8f78d8a28310c797ae0c569c014d";
+
+    sha256 = "0pk8zc6a449r7zflnik14172vbvsa747z66hai43f6sbpz7a47rg";
+    crates = [
+      {
+        name = "proxmox-client";
+        path = "proxmox-client";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-shared-memory-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "eb1116c1e3fd27e391a9dde487eabc673368a6c5";
+
+    sha256 = "0gccrgy2qlggqwhb42zkypn8bdg05xxd62g4gaz9mzc1wby9bk34";
+    crates = [
+      {
+        name = "proxmox-shared-memory";
+        path = "proxmox-shared-memory";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-schema-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "ed34cf12938cf9f78162ba5a2d98956b416a8883";
+
+    sha256 = "0qk5jzlp8ks9gpaya88hs1v7slrhswxbwd023kkc8wg92bb1g7ir";
+    crates = [
+      {
+        name = "proxmox-schema";
+        path = "proxmox-schema";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-systemd-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "fb3e8ca768c5c815fc55ca78e095df35a1c06d78";
+
+    sha256 = "1lblv6sw4rrwf1xha3hz727mwas90zqykx9nwrw60s0sabw5pyic";
+    crates = [
+      {
+        name = "proxmox-systemd";
+        path = "proxmox-systemd";
+      }
+    ];
+  }
+  {
+    name = "librust-proxmox-node-status-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "fe863e169e9c1a775a4065dd007ab9ceed4ce07b";
+
+    sha256 = "1w24pmiqhxqbkafc2kwra0vnzrhjhrf1fw1b6vyqhljzhl3s16jy";
+    crates = [
+      {
+        name = "proxmox-node-status";
+        path = "proxmox-node-status";
+      }
+    ];
+  }
+  {
     name = "librust-pxar-dev";
     url = "git://git.proxmox.com/git/pxar.git";
-    rev = "993c66fcb8819770f279cb9fb4d13f58f367606c";
+    rev = "957acc8917294a62d829d51e06cff9dc88845fb3";
 
-    sha256 = "1bqfdq15kq45wrqmsh559ijbv48k73fjca5l4198mflgii6f942p";
+    sha256 = "1fimxfa143dh287b43i7n9bh6k9r3h69yp9pkxkjab7fy3jrz92m";
     crates = [
       {
         name = "pxar";
@@ -702,3 +819,4 @@
     ];
   }
 ]
+

--- a/pkgs/proxmox-backup-qemu/sources.nix
+++ b/pkgs/proxmox-backup-qemu/sources.nix
@@ -652,9 +652,9 @@
   {
     name = "librust-proxmox-uuid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "aced6d2b7d8c47e1a5825d825ac988eac7d90c8a";
+    rev = "391412712c4dd6f86157eb0c3767ef6e36750896";
 
-    sha256 = "01famhymykh5l99iq5gg6rifbfn8gwxpi4zlpnihbiv83kqx6xvc";
+    sha256 = "sha256-c3Z7LveHM34DNlEcVpFFgP8sQFIDYjPsxO6wdK2RdgE=";
     crates = [
       {
         name = "proxmox-uuid";

--- a/pkgs/proxmox-i18n/default.nix
+++ b/pkgs/proxmox-i18n/default.nix
@@ -19,12 +19,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "proxmox-i18n";
-  version = "3.6.1";
+  version = "3.6.6";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/${pname}.git";
-    rev = "b43940b4d4387ebb9f101d5659704cb1126da0af";
-    hash = "sha256-r9u7KUqz1eh1imWH0mKpOH4Z1T6vgNavl9+QLk33r7M=";
+    rev = "b86b5b63ed94b01e0378a42f11467fd1e5851997";
+    hash = "sha256-XqYovh3rwcobOhyKpRiZqpARoxl5n4jVD4rNl1ePTtg=";
   };
 
   postPatch = ''

--- a/pkgs/proxmox-wasm-builder/sources.nix
+++ b/pkgs/proxmox-wasm-builder/sources.nix
@@ -652,9 +652,9 @@
   {
     name = "librust-proxmox-uuid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "aced6d2b7d8c47e1a5825d825ac988eac7d90c8a";
+    rev = "391412712c4dd6f86157eb0c3767ef6e36750896";
     
-    sha256 = "01famhymykh5l99iq5gg6rifbfn8gwxpi4zlpnihbiv83kqx6xvc";
+    sha256 = "sha256-c3Z7LveHM34DNlEcVpFFgP8sQFIDYjPsxO6wdK2RdgE=";
     crates = [
       {
         name = "proxmox-uuid";

--- a/pkgs/proxmox-widget-toolkit/default.nix
+++ b/pkgs/proxmox-widget-toolkit/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   pname = "proxmox-widget-toolkit";
-  version = "5.0.6";
+  version = "5.1.4";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/proxmox-widget-toolkit.git";
-    rev = "33cc00aecae8f14c22b6c21e2ed4526ede099a1b";
-    hash = "sha256-sUeulqXX3t4Dz+TydbU9JU1iwC7V4k192bUHqNaUexE=";
+    rev = "d38cd3d923f1919556bc67ecff7b95ae20f3052f";
+    hash = "sha256-So3KbPOzsohiwzev+5IArKAR6/PIUQRwo39MxMJPong=";
   };
 
   sourceRoot = "${src.name}/src";

--- a/pkgs/proxmox-widget-toolkit/default.nix
+++ b/pkgs/proxmox-widget-toolkit/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   pname = "proxmox-widget-toolkit";
-  version = "5.1.4";
+  version = "5.1.5";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/proxmox-widget-toolkit.git";
-    rev = "d38cd3d923f1919556bc67ecff7b95ae20f3052f";
-    hash = "sha256-So3KbPOzsohiwzev+5IArKAR6/PIUQRwo39MxMJPong=";
+    rev = "e0798f947fb727ce57f3423e782465a3c9115cfe";
+    hash = "sha256-wXHVgWnq/HUDJ3O6Jkgk521+AQwd9cLR4StACGO6buc=";
   };
 
   sourceRoot = "${src.name}/src";

--- a/pkgs/pve-access-control/default.nix
+++ b/pkgs/pve-access-control/default.nix
@@ -20,12 +20,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-access-control";
-    version = "9.0.4";
+    version = "9.0.5";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "3e9da0c8e3845bba9d2d61f537a4d3278eb9f477";
-      hash = "sha256-+puV+Pt1DE9b1nPmbH5OoIH/fEhBUgbb4XlKNCZVQuI=";
+      rev = "df0a60e74d8040f3a8f066c840a76c4b5b8aff9e";
+      hash = "sha256-oOXmlHts7KUjzqGLAnqhCvQ0NfX7wRBF+t55UeVjyLI=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-access-control/default.nix
+++ b/pkgs/pve-access-control/default.nix
@@ -20,12 +20,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-access-control";
-    version = "9.0.3";
+    version = "9.0.4";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "2c67c26f61138e9a97c5aab450d05a865eea6413";
-      hash = "sha256-7ZZQAKgqIpzAqU+hbgiZB6uEkTQkTrovpUUmUKKlcRY=";
+      rev = "3e9da0c8e3845bba9d2d61f537a4d3278eb9f477";
+      hash = "sha256-+puV+Pt1DE9b1nPmbH5OoIH/fEhBUgbb4XlKNCZVQuI=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-apiclient/default.nix
+++ b/pkgs/pve-apiclient/default.nix
@@ -13,12 +13,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-apiclient";
-    version = "3.4.0";
+    version = "3.4.2";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "6138da4f9d2e96db4a809fd8d4927dec43f8a9f9";
-      hash = "sha256-2Dg364G2M8tBPPWSF2w2Ebz8UahYdopslyqqNWuLYVY=";
+      rev = "a56152820da7d97b2c2b1f9dc56d4775db50ec20";
+      hash = "sha256-sJr1x1/UlP0N986tOZ1NJSSXU526Rn3jwAv6p5B5Tw4=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-cluster/default.nix
+++ b/pkgs/pve-cluster/default.nix
@@ -42,12 +42,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-cluster";
-    version = "9.0.6";
+    version = "9.0.7";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "253de0cdfe1cd53ab8940c2e5147d363c82f9e46";
-      hash = "sha256-YFpL4XnfJPdeP8O83IZZk0cWmGbSuPqJEvWkWHcMvR0=";
+      rev = "300978f19f91e3e226a80bb69ba6a21ec279e869";
+      hash = "sha256-xQP+3jHqHecVFqsSMWel0CYhAGws8MQOKayQatWcNH0=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-common/default.nix
+++ b/pkgs/pve-common/default.nix
@@ -72,12 +72,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-common";
-    version = "9.0.11";
+    version = "9.1.0";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "569bd924e85d5e72b952407f4f87700bc7f46140";
-      hash = "sha256-/lNu9Ij3OJMRDlNQk9y/EKBb8UrYznVyE7jOXXrK5Jo=";
+      rev = "068c9f7c8b1756c7bf0a5f5abddf7de83743ae02";
+      hash = "sha256-fpQ6VUIbht80ttJbFUR5lbtCu1vukTpHqUvzpWn0Y/w=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-common/default.nix
+++ b/pkgs/pve-common/default.nix
@@ -72,12 +72,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-common";
-    version = "9.1.0";
+    version = "9.1.4";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "068c9f7c8b1756c7bf0a5f5abddf7de83743ae02";
-      hash = "sha256-fpQ6VUIbht80ttJbFUR5lbtCu1vukTpHqUvzpWn0Y/w=";
+      rev = "404a109680bd147766e39b8fda482e26b5e97b2c";
+      hash = "sha256-6m+uWPCvBmMKj/75zqZ70Ip7GWKW4nMfuIoga2n2500=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-container/default.nix
+++ b/pkgs/pve-container/default.nix
@@ -18,12 +18,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-container";
-    version = "6.0.13";
+    version = "6.0.18";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "ab898eb9f0280285976d02232094e5f6d0ae168d";
-      hash = "sha256-MLvWrNwPdlvWlcqcQ8ZCsvw9rCkptHfHVZxlMYmjcXA=";
+      rev = "963730e937c5ec51d0618b9ff9d4e5f6687cb3a3";
+      hash = "sha256-tGp6SMgGWOa2945WqocoFZynJ1fB2nGZvEsCFpDlx+Q=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-docs/default.nix
+++ b/pkgs/pve-docs/default.nix
@@ -5,14 +5,90 @@
   perl540,
   proxmox-widget-toolkit,
   asciidoc,
+  dblatex,
+  graphviz,
+  imagemagick,
   librsvg,
+  makeWrapper,
   pve-update-script,
+  texlive,
 }:
 
 let
-  perlDeps = with perl540.pkgs; [ JSON ];
+  perlDeps = with perl540.pkgs; [
+    JSON
+    TemplateToolkit
+  ];
 
   perlEnv = perl540.withPackages (_: perlDeps);
+
+  # Texlive packages required for PDF generation
+  texliveEnv = texlive.withPackages (ps: with ps; [
+    scheme-medium
+    appendix
+    bibtopic
+    bookmark
+    changebar
+    colortbl
+    enumitem
+    eepic
+    fancybox
+    fancyhdr
+    fancyvrb
+    float
+    footmisc
+    lastpage
+    listings
+    multirow
+    overpic
+    pdfpages
+    psnfss
+    subfigure
+    titlesec
+    upquote
+    courier
+    helvetic
+    rsfs
+    pxfonts
+    symbol
+    txfonts
+    zapfding
+  ]);
+
+  # Override dblatex to use our texlive environment
+  dblatexBase = dblatex.override {
+    enableAllFeatures = true;
+    tex = texliveEnv;
+  };
+
+  # Wrap dblatex to add librsvg to PATH (needed for SVG conversion)
+  dblatexCustom = stdenv.mkDerivation {
+    pname = "dblatex-wrapped";
+    version = dblatexBase.version;
+    
+    nativeBuildInputs = [ makeWrapper ];
+    
+    buildCommand = ''
+      mkdir -p $out/bin $out/share
+      
+      # Wrap the dblatex binary
+      makeWrapper ${dblatexBase}/bin/dblatex $out/bin/dblatex \
+        --prefix PATH : "${librsvg}/bin"
+      
+      # Link share directory (contains XSL files etc.)
+      ln -s ${dblatexBase}/share/dblatex $out/share/dblatex
+    '';
+  };
+
+  # Use asciidoc with enableStandardFeatures which:
+  # - Patches a2x.py ENV to include PATH for subprocess calls
+  # - Hardcodes absolute paths for dblatex, xsltproc, xmllint, epubcheck, etc.
+  # Override both texliveMinimal and dblatexFull to use our custom wrapped dblatex.
+  asciidocFull = asciidoc.override {
+    enableStandardFeatures = true;
+    texliveMinimal = texliveEnv;
+    dblatexFull = dblatexCustom;
+  };
 in
 
 stdenv.mkDerivation rec {
@@ -26,27 +102,46 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    patchShebangs scan-adoc-refs
+    patchShebangs scan-adoc-refs png-verify.pl
+    sed -i '1s|#!/usr/bin/perl|#!${perlEnv}/bin/perl|' asciidoc-pve.in
+
     sed -i Makefile \
       -e '/GITVERSION/d' \
       -e '/pkg-info/d' \
       -e "s|/usr/share/javascript/proxmox-widget-toolkit-dev|${proxmox-widget-toolkit}/share/javascript/proxmox-widget-toolkit|" \
-      -e 's|/usr||' \
-      -e "s/gen-install doc-install mediawiki-install/gen-install mediawiki-install/" \
-      -e 's|\./asciidoc-pve|$out/bin/asciidoc-pve|'
-    #find . -type f | xargs sed -i -e "s|/usr|$out|"
+      -e 's|/usr||'
+
+    sed -i images/Makefile -e 's|/usr/share/pve-docs|/share/pve-docs|'
+
+    # Fix PVE_DOCBOOK_CONF: a2x always forces --backend docbook which overrides -b option.
+    # Using -f to load pve-docbook.conf after the forced backend ensures [sect5] is defined.
+    sed -i Makefile -e 's|PVE_DOCBOOK_CONF=-b.*pve-docbook|PVE_DOCBOOK_CONF=-f asciidoc/pve-docbook.conf|'
+
+    # Fix asciidoc include paths for NixOS: replace Debian paths with Nix store paths
+    # The pve-html.conf references /etc/asciidoc/{stylesheets,javascripts} which don't exist on NixOS
+    # We need to point to the actual asciidoc package resources directory
+    ASCIIDOC_RESOURCES=$(find ${asciidocFull}/lib -type d -name resources -path '*/asciidoc/*' | head -1)
+    sed -i asciidoc/pve-html.conf \
+      -e "s|/etc/asciidoc/stylesheets|$ASCIIDOC_RESOURCES/stylesheets|g" \
+      -e "s|/etc/asciidoc/javascripts|$ASCIIDOC_RESOURCES/javascripts|g"
   '';
 
-  buildInputs = [
-    asciidoc
+  nativeBuildInputs = [
+    asciidocFull
+    graphviz
+    imagemagick
     librsvg
+  ];
+
+  buildInputs = [
     perlEnv
   ];
+
   propagatedBuildInputs = perlDeps;
 
   makeFlags = [
     "GITVERSION=${src.rev}"
-    "INDEX_INCLUDES="
+    "DOCRELEASE=${version}"
     "DESTDIR=$(out)"
   ];
 

--- a/pkgs/pve-docs/default.nix
+++ b/pkgs/pve-docs/default.nix
@@ -17,12 +17,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "pve-docs";
-  version = "9.1.1";
+  version = "9.1.2";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/${pname}.git";
-    rev = "a93964e4a1fdc81fafee4c7e108ea18afa476c5e";
-    hash = "sha256-rq45Sb0hTl73DNDESvqimnjjlVBbE/0g2eKR9A9NvGg=";
+    rev = "b4b8695af1321d5e2f5bf87e6c728662ea5bf6df";
+    hash = "sha256-zYQWB85mzrKzyClSQWngtoLlLjH4NbhDaS7fzunioCY=";
   };
 
   postPatch = ''

--- a/pkgs/pve-docs/default.nix
+++ b/pkgs/pve-docs/default.nix
@@ -17,12 +17,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "pve-docs";
-  version = "9.0.8";
+  version = "9.1.1";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/${pname}.git";
-    rev = "6fa010b88a5f31a38ac063aa66b899be5425de1f";
-    hash = "sha256-0TaegDUFl1C0n1mMKSM2JdJ/h+mnMoDro/6Sa2uH2O8=";
+    rev = "a93964e4a1fdc81fafee4c7e108ea18afa476c5e";
+    hash = "sha256-rq45Sb0hTl73DNDESvqimnjjlVBbE/0g2eKR9A9NvGg=";
   };
 
   postPatch = ''

--- a/pkgs/pve-firewall/default.nix
+++ b/pkgs/pve-firewall/default.nix
@@ -31,12 +31,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-firewall";
-    version = "6.0.3";
+    version = "6.0.4";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "e88b00cc42c60d373fee4befd5c3649640313a70";
-      hash = "sha256-W0lD06tZgRBlY7orBxMJTDVyURA/QbARB5KSCTwsDdQ=";
+      rev = "aadddcfd474962c710ad0fb90365a593eb7ce736";
+      hash = "sha256-sGSB2Qlz97cwci06dkEIUf7Ol/8wHIKNfyY+TXD36mw=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-ha-manager/default.nix
+++ b/pkgs/pve-ha-manager/default.nix
@@ -28,12 +28,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-ha-manager";
-    version = "5.0.8";
+    version = "5.1.0";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "9b2729f03c9d38aafe2b59aa193629228186492d";
-      hash = "sha256-Vgy6Yx8AJqtM6/M+7qgcDMlDIpu912rBpNh858Ga29I=";
+      rev = "df1794d1c73ee06f61b025668e1287a5b6cca4e2";
+      hash = "sha256-67lt0k1egzNmr3HP8hS/KYs0Hg3TBPOvDmMV8Ia6WOY=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-ha-manager/default.nix
+++ b/pkgs/pve-ha-manager/default.nix
@@ -28,12 +28,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-ha-manager";
-    version = "5.0.5";
+    version = "5.0.8";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "a75d95d378be798b536a593d258c5f203a39ef9c";
-      hash = "sha256-KZnsNWmgYBLZ5D2stZ85f7ywI61LUoqiOnnDk4+eUAw=";
+      rev = "9b2729f03c9d38aafe2b59aa193629228186492d";
+      hash = "sha256-Vgy6Yx8AJqtM6/M+7qgcDMlDIpu912rBpNh858Ga29I=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-http-server/default.nix
+++ b/pkgs/pve-http-server/default.nix
@@ -6,6 +6,7 @@
   proxmox-i18n,
   proxmox-widget-toolkit,
   extjs,
+  qrcodejs,
   font-awesome_4,
   fonts-font-logos,
   twitterBootstrap,
@@ -50,6 +51,7 @@ perl540.pkgs.toPerlModule (
       ln -s ${proxmox-i18n}/share/pve-yew-mobile-i18n $out/share
       ln -s ${proxmox-widget-toolkit}/share/javascript/proxmox-widget-toolkit $out/share/javascript
       ln -s ${extjs}/share/javascript/extjs $out/share/javascript
+      ln -s ${qrcodejs}/share/javascript/qrcodejs $out/share/javascript
       ln -s ${pve-yew-mobile-gui}/share/pve-yew-mobile-gui $out/share
       ln -s ${fonts-font-awesome}/share/fonts-font-awesome $out/share
       ln -s ${fonts-font-logos}/share/fonts-font-logos $out/share

--- a/pkgs/pve-http-server/default.nix
+++ b/pkgs/pve-http-server/default.nix
@@ -8,6 +8,7 @@
   extjs,
   font-awesome_4,
   fonts-font-logos,
+  twitterBootstrap,
   pve-yew-mobile-gui,
   pve-update-script,
 }:
@@ -51,6 +52,7 @@ perl540.pkgs.toPerlModule (
       ln -s ${pve-yew-mobile-gui}/share/pve-yew-mobile-gui $out/share
       ln -s ${fonts-font-awesome}/share/fonts-font-awesome $out/share
       ln -s ${fonts-font-logos}/share/fonts-font-logos $out/share
+      ln -s ${twitterBootstrap}/ $out/share/bootstrap5
     '';
 
     passthru.updateScript = pve-update-script {

--- a/pkgs/pve-http-server/default.nix
+++ b/pkgs/pve-http-server/default.nix
@@ -44,7 +44,8 @@ perl540.pkgs.toPerlModule (
 
     postFixup = ''
       find $out -type f | xargs sed -i \
-        -e "s|/usr/share/javascript|$out/share/javascript|"
+        -e "s|/usr/share/javascript|$out/share/javascript|" \
+        -e "s|/usr/share/bootstrap-html|$out/share/bootstrap-html|"
       mkdir -p $out/share/javascript
       ln -s ${proxmox-i18n}/share/pve-yew-mobile-i18n $out/share
       ln -s ${proxmox-widget-toolkit}/share/javascript/proxmox-widget-toolkit $out/share/javascript
@@ -52,7 +53,7 @@ perl540.pkgs.toPerlModule (
       ln -s ${pve-yew-mobile-gui}/share/pve-yew-mobile-gui $out/share
       ln -s ${fonts-font-awesome}/share/fonts-font-awesome $out/share
       ln -s ${fonts-font-logos}/share/fonts-font-logos $out/share
-      ln -s ${twitterBootstrap}/ $out/share/bootstrap5
+      ln -s ${twitterBootstrap}/ $out/share/bootstrap-html
     '';
 
     passthru.updateScript = pve-update-script {

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -128,6 +128,7 @@ perl540.pkgs.toPerlModule (
         -e "s|/usr/share/pve-yew-mobile-i18n|${proxmox-i18n}/share/pve-yew-mobile-i18n|" \
         -e "s|/usr/share/fonts-font-awesome|${pve-http-server}/share/fonts-font-awesome|" \
         -e "s|/usr/share/fonts-font-logos|${pve-http-server}/share/fonts-font-logos|" \
+        -e "s|/usr/share/pve-docs|${pve-docs}/share/pve-docs|" \
         -e "s|/usr/share/pve-i18n|${proxmox-i18n}/share/pve-i18n|" \
         -e "s|/usr/share/pve-manager|$out/share/pve-manager|" \
         -e "s|/usr/share/zoneinfo|${tzdata}/share/zoneinfo|" \

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -122,7 +122,7 @@ perl540.pkgs.toPerlModule (
       find $out/lib -type f | xargs sed -i \
         -e "/API2::APT/d" \
         -e "/ENV{'PATH'}/d" \
-        -e "s|/usr/share/bootstrap-html|${pve-http-server}/share/bootstrap5|" \
+        -e "s|/usr/share/bootstrap-html|${pve-http-server}/share/bootstrap-html|" \
         -e "s|/usr/share/javascript|${pve-http-server}/share/javascript|" \
         -e "s|/usr/share/pve-yew-mobile-gui|${pve-yew-mobile-gui}/share/pve-yew-mobile-gui|" \
         -e "s|/usr/share/pve-yew-mobile-i18n|${proxmox-i18n}/share/pve-yew-mobile-i18n|" \

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -65,12 +65,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-manager";
-    version = "9.1.1";
+    version = "9.1.4";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "42db4a6cf33dac83";
-      hash = "sha256-cguahSicy6KW/4UQ9ibeDT3eHZZltTDxgcLPDLsjgj4=";
+      rev = "5ac30304265fbd8e";
+      hash = "sha256-nx6FyDSktgA70uGZPdjDsKP82nXrftlZ/M9Anghq2kU=";
     };
 
     patches = [

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -65,12 +65,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-manager";
-    version = "9.0.11";
+    version = "9.1.1";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "3bf5476b8a4699e2";
-      hash = "sha256-Nvi/XxvgYafZTzfzaB+1u6lwtfbCJrua+Gxq6CkAahQ=";
+      rev = "42db4a6cf33dac83";
+      hash = "sha256-cguahSicy6KW/4UQ9ibeDT3eHZZltTDxgcLPDLsjgj4=";
     };
 
     patches = [

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -122,6 +122,7 @@ perl540.pkgs.toPerlModule (
       find $out/lib -type f | xargs sed -i \
         -e "/API2::APT/d" \
         -e "/ENV{'PATH'}/d" \
+        -e "s|/usr/share/bootstrap-html|${pve-http-server}/share/bootstrap5|" \
         -e "s|/usr/share/javascript|${pve-http-server}/share/javascript|" \
         -e "s|/usr/share/pve-yew-mobile-gui|${pve-yew-mobile-gui}/share/pve-yew-mobile-gui|" \
         -e "s|/usr/share/pve-yew-mobile-i18n|${proxmox-i18n}/share/pve-yew-mobile-i18n|" \

--- a/pkgs/pve-network/default.nix
+++ b/pkgs/pve-network/default.nix
@@ -32,12 +32,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-network";
-    version = "1.1.8";
+    version = "1.2.4";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "3938fa1c6e88cc9d8eebcd8ba1919a5417e109e0";
-      hash = "sha256-A5PZTudip6mGqi0TcHAX7+bh0htGjzqza6NLNvhjPp4=";
+      rev = "3d9449686cd4a3427dda3e3ef9430b7630c3555b";
+      hash = "sha256-AJpxwrpGiOJl4LCGQcHzfD7hzdJN+2giI5JkY4Xmhls=";
     };
 
     sourceRoot = "${src.name}/src/PVE";

--- a/pkgs/pve-qemu-server/default.nix
+++ b/pkgs/pve-qemu-server/default.nix
@@ -59,12 +59,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-qemu-server";
-    version = "9.1.0";
+    version = "9.1.3";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/qemu-server.git";
-      rev = "2cf3f809dda5712b99016de7464d26e9515d32d9";
-      hash = "sha256-+mkgdxQ6EdNZYFf46sdSZ13UNcOduvkR8k6DhoNtao8=";
+      rev = "e781d9713fb3d45a523fe14db6cd99ac60bbfbb5";
+      hash = "sha256-n5B9qklDXiwYg2uGQbCmkjwaC7xlC3MVL+U2uxB9Shw=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-qemu-server/default.nix
+++ b/pkgs/pve-qemu-server/default.nix
@@ -21,6 +21,7 @@
   swtpm,
   libglvnd,
   pve-update-script,
+  python3Packages,
 }:
 
 let
@@ -58,12 +59,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-qemu-server";
-    version = "9.0.23";
+    version = "9.1.0";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/qemu-server.git";
-      rev = "78e5d8a8d06a061c464dfd5e3d794f4d729d02b1";
-      hash = "sha256-ujAVNq5bGxnmMAGLlfzJ/pvCoItsPohXvl3qTJhhsKA=";
+      rev = "2cf3f809dda5712b99016de7464d26e9515d32d9";
+      hash = "sha256-+mkgdxQ6EdNZYFf46sdSZ13UNcOduvkR8k6DhoNtao8=";
     };
 
     sourceRoot = "${src.name}/src";
@@ -135,6 +136,7 @@ perl540.pkgs.toPerlModule (
         -e "s|/var/lib/qemu-server|$out/lib/qemu-server|" \
         -e "s|/usr/share/pve-edk2-firmware|${pve-edk2-firmware}/usr/share/pve-edk2-firmware|" \
         -e 's|/etc/swtpm_setup.conf|${swtpm}/etc/swtpm_setup.conf|' \
+        -e "s|virt-fw-vars|${python3Packages.virt-firmware}/bin/virt-fw-vars|g" \
         #-e "s|/usr/bin/proxmox-backup-client|${proxmox-backup-client}/bin/proxmox-backup-client|" \
         #-e "s|/usr/sbin/qm|$out/bin/qm|" \
         #-e "s|/usr/bin/qemu|${pve-qemu}/bin/qemu|" \

--- a/pkgs/pve-qemu/default.nix
+++ b/pkgs/pve-qemu/default.nix
@@ -16,13 +16,13 @@ let
 in
 (qemu.overrideAttrs (old: rec {
   pname = "pve-qemu";
-  version = "10.0.2-4";
+  version = "10.1.2-1";
 
   src =
     (fetchgit {
       url = "git://git.proxmox.com/git/pve-qemu.git";
-      rev = "839b53bab89fddb7a7fb3a1d722e05df932cce4e";
-      hash = "sha256-pu0Mp4F1ppmD1R0O31c8tm0jTlfsxuxYFN03+YPrtBc=";
+      rev = "49bb66e86b9e894e8db47a000033088bebc03881";
+      hash = "sha256-Ney7iKfZne8WRfyYtvkVk9POheykQesBTZJc4k3l1LY=";
       fetchSubmodules = true;
 
       # Download subprojects managed by meson

--- a/pkgs/pve-qemu/default.nix
+++ b/pkgs/pve-qemu/default.nix
@@ -7,6 +7,7 @@
   pkg-config,
   meson,
   cacert,
+  git,
   pve-update-script,
 }:
 
@@ -16,19 +17,20 @@ let
 in
 (qemu.overrideAttrs (old: rec {
   pname = "pve-qemu";
-  version = "10.1.2-1";
+  version = "10.1.2-5";
 
   src =
     (fetchgit {
       url = "git://git.proxmox.com/git/pve-qemu.git";
-      rev = "49bb66e86b9e894e8db47a000033088bebc03881";
-      hash = "sha256-Ney7iKfZne8WRfyYtvkVk9POheykQesBTZJc4k3l1LY=";
+      rev = "de7f8fe356c7b1d346c3c15c971f7a0dcd11e70e";
+      hash = "sha256-gDKhnM0Rf20Fd82VQhrCDrrxB9e/ZCDYYpDOVOoxcmE=";
       fetchSubmodules = true;
 
       # Download subprojects managed by meson
       postFetch = ''
         cd "$out/qemu"
         export NIX_SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+        export PATH="${git}/bin:$PATH"
         for prj in subprojects/*.wrap; do
           ${lib.getExe meson} subprojects download "$(basename "$prj" .wrap)"
         done

--- a/pkgs/pve-rs/Cargo.lock
+++ b/pkgs/pve-rs/Cargo.lock
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "pve-rs"
-version = "0.11.1"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "base32",

--- a/pkgs/pve-rs/Cargo.lock
+++ b/pkgs/pve-rs/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
  "object",
 ]
@@ -92,9 +92,9 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -104,9 +104,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -141,15 +141,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "base64urlsafedata"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215ee31f8a88f588c349ce2d20108b2ed96089b96b9c2b03775dc35dd72938e8"
+checksum = "42f7f6be94fa637132933fd0a68b9140bcb60e3d46164cb68e82a2bb8d102b3a"
 dependencies = [
  "base64 0.21.7",
  "pastey",
@@ -173,29 +173,25 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.43"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -213,16 +209,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -256,8 +252,8 @@ version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
  "unicode-xid 0.2.6",
 ]
 
@@ -308,7 +304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -345,9 +341,19 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -356,8 +362,22 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "strsim",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -368,10 +388,21 @@ checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.103",
- "quote 1.0.41",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
  "strsim",
- "syn 2.0.108",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -380,16 +411,16 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
- "quote 1.0.41",
- "syn 2.0.108",
+ "darling_core 0.21.3",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -427,6 +458,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,9 +506,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -514,7 +576,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -583,7 +645,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -594,16 +656,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.4"
+name = "filetime"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -691,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -715,13 +788,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -768,9 +853,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -798,23 +889,22 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -832,9 +922,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -856,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -869,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -882,11 +972,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -897,42 +986,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -980,12 +1065,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -1001,15 +1086,25 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1051,15 +1146,26 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1069,15 +1175,15 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -1118,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -1197,26 +1303,25 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -1256,9 +1361,9 @@ checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
  "base64 0.22.1",
  "chrono",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "http",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1269,11 +1374,28 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1308,7 +1430,7 @@ dependencies = [
  "oauth2",
  "p256",
  "p384",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "serde-value",
@@ -1324,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.74"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1343,9 +1465,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1356,9 +1478,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.110"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -1435,16 +1557,16 @@ dependencies = [
 name = "perlmod-macro"
 version = "0.10.0"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "pest"
-version = "2.8.3"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
+checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1452,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.3"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
+checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1462,22 +1584,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.3"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
+checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.3"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
+checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
  "sha2",
@@ -1524,9 +1646,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -1556,6 +1678,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,26 +1710,26 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proxmox-api-macro"
-version = "1.4.1"
+version = "1.4.4"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "proxmox-apt"
-version = "0.99.2"
+version = "0.99.6"
 dependencies = [
  "anyhow",
  "apt-pkg-native",
@@ -1605,10 +1749,11 @@ dependencies = [
 
 [[package]]
 name = "proxmox-apt-api-types"
-version = "2.0.0"
+version = "2.0.4"
 dependencies = [
  "proxmox-config-digest",
  "proxmox-schema",
+ "proxmox-serde",
  "serde",
  "serde_plain",
 ]
@@ -1623,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-config-digest"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -1635,18 +1780,20 @@ dependencies = [
 
 [[package]]
 name = "proxmox-frr"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "proxmox-network-types",
  "proxmox-sdn-types",
- "thiserror 2.0.17",
+ "serde",
+ "serde_repr",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "proxmox-http"
-version = "1.0.2"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "http",
@@ -1669,7 +1816,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-human-byte"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "proxmox-schema",
@@ -1679,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-io"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "endian_trait",
 ]
@@ -1705,18 +1852,18 @@ dependencies = [
 
 [[package]]
 name = "proxmox-network-types"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proxmox-schema",
  "regex",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "proxmox-notify"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1743,6 +1890,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proxmox-oci"
+version = "0.2.1"
+dependencies = [
+ "flate2",
+ "oci-spec",
+ "proxmox-io",
+ "sha2",
+ "tar",
+ "thiserror 1.0.69",
+ "zstd",
+]
+
+[[package]]
 name = "proxmox-openid"
 version = "1.0.2"
 dependencies = [
@@ -1761,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-resource-scheduling"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -1769,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-schema"
-version = "4.1.1"
+version = "5.0.1"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1782,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-sdn-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "proxmox-schema",
@@ -1793,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-section-config"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -1805,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-sendmail"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "percent-encoding",
@@ -1815,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-serde"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "proxmox-base64",
@@ -1839,14 +1999,14 @@ dependencies = [
 name = "proxmox-sortable-macro"
 version = "1.0.0"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "proxmox-subscription"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -1878,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-tfa"
-version = "6.0.3"
+version = "6.0.4"
 dependencies = [
  "anyhow",
  "base32",
@@ -1919,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-ve-config"
-version = "0.4.2"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1936,15 +2096,15 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
+checksum = "1fa96cb91275ed31d6da3e983447320c4eb219ac180fa1679a0889ff32861e2d"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -1952,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "pve-rs"
-version = "0.10.10"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "base32",
@@ -1972,6 +2132,7 @@ dependencies = [
  "proxmox-log",
  "proxmox-network-types",
  "proxmox-notify",
+ "proxmox-oci",
  "proxmox-openid",
  "proxmox-resource-scheduling",
  "proxmox-section-config",
@@ -1999,11 +2160,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
- "proc-macro2 1.0.103",
+ "proc-macro2 1.0.106",
 ]
 
 [[package]]
@@ -2025,8 +2186,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2036,7 +2207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2045,7 +2226,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2063,9 +2262,9 @@ version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2121,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest",
@@ -2132,7 +2331,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -2159,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -2171,19 +2370,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
@@ -2193,12 +2383,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "schannel"
@@ -2223,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -2331,22 +2515,22 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2370,18 +2554,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.15.1"
+name = "serde_repr"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa66c845eee442168b2c8134fec70ac50dc20e760769c8ba0ad1319ca1959b04"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "schemars 0.9.0",
- "schemars 1.0.4",
+ "schemars 1.2.0",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -2390,14 +2585,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.1"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91a903660542fced4e99881aa481bdbaec1634568ee02e0b8bd57c64cb38955"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "darling 0.21.3",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2433,14 +2628,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
@@ -2462,9 +2657,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -2512,6 +2707,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,12 +2743,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
  "unicode-ident",
 ]
 
@@ -2545,16 +2758,27 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
@@ -2585,11 +2809,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2598,20 +2822,20 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2625,30 +2849,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2656,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2666,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "libc",
  "mio",
@@ -2679,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2690,20 +2914,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2711,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-journald"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0b4143302cf1022dac868d521e36e8b27691f72c84b3311750d5188ebba657"
+checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
 dependencies = [
  "libc",
  "tracing-core",
@@ -2733,9 +2957,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -2759,9 +2983,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2795,9 +3019,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "ureq"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ba1025f18a4a3fc3e9b48c868e9beb4f24f4b4b1a325bada26bd4119f46537"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
 dependencies = [
  "base64 0.22.1",
  "der",
@@ -2805,7 +3029,6 @@ dependencies = [
  "log",
  "native-tls",
  "percent-encoding",
- "rustls-pemfile",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
@@ -2814,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64 0.22.1",
  "http",
@@ -2826,14 +3049,15 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2850,13 +3074,13 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -2886,18 +3110,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2908,41 +3132,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
- "quote 1.0.41",
+ "quote 1.0.44",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "webauthn-attestation-ca"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77a2892ec44032e6c48dad9aad1b05fada09c346ada11d8d32db119b4b4f205"
+checksum = "fafcf13f7dc1fb292ed4aea22cdd3757c285d7559e9748950ee390249da4da6b"
 dependencies = [
  "base64urlsafedata",
  "openssl",
@@ -2954,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7c3a2f9c8bddd524e47bbd427bcf3a28aa074de55d74470b42a91a41937b8e"
+checksum = "1b24d082d3360258fefb6ffe56123beef7d6868c765c779f97b7a2fcf06727f8"
 dependencies = [
  "base64urlsafedata",
  "serde",
@@ -2968,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-core"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f1d80f3146382529fe70a3ab5d0feb2413a015204ed7843f9377cd39357fc4"
+checksum = "15784340a24c170ce60567282fb956a0938742dbfbf9eff5df793a686a009b8b"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
@@ -2979,8 +3203,8 @@ dependencies = [
  "nom 7.1.3",
  "openssl",
  "openssl-sys",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "serde",
  "serde_cbor_2",
  "serde_json",
@@ -2995,9 +3219,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-proto"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e786894f89facb9aaf1c5f6559670236723c98382e045521c76f3d5ca5047bd"
+checksum = "16a1fb2580ce73baa42d3011a24de2ceab0d428de1879ece06e02e8c416e497c"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
@@ -3008,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d651ec480de84b762e7be71e6efa7461699c19d9e2c272c8d93455f567786e"
+checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3023,7 +3247,7 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
@@ -3034,9 +3258,9 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3045,16 +3269,10 @@ version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -3068,7 +3286,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3077,7 +3295,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3104,7 +3322,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3129,7 +3347,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -3238,15 +3456,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x509-parser"
@@ -3266,12 +3484,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.8.0"
+name = "xattr"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
- "serde",
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -3279,34 +3506,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3324,9 +3551,9 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -3338,9 +3565,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3349,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3360,13 +3587,47 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.41",
- "syn 2.0.108",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[patch.unused]]
@@ -3375,19 +3636,19 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "pbs-api-types"
-version = "1.0.3"
+version = "1.0.9"
 
 [[patch.unused]]
 name = "proxmox-access-control"
-version = "1.0.0"
+version = "1.3.1"
 
 [[patch.unused]]
 name = "proxmox-acme"
-version = "1.0.2"
+version = "1.0.3"
 
 [[patch.unused]]
 name = "proxmox-acme-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-async"
@@ -3395,7 +3656,7 @@ version = "0.5.0"
 
 [[patch.unused]]
 name = "proxmox-auth-api"
-version = "1.0.3"
+version = "1.0.5"
 
 [[patch.unused]]
 name = "proxmox-borrow"
@@ -3403,11 +3664,11 @@ version = "1.1.0"
 
 [[patch.unused]]
 name = "proxmox-client"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-compression"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-daemon"
@@ -3415,15 +3676,15 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-dns-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-ldap"
-version = "1.0.0"
+version = "1.1.0"
 
 [[patch.unused]]
 name = "proxmox-login"
-version = "1.0.1"
+version = "1.0.3"
 
 [[patch.unused]]
 name = "proxmox-metrics"
@@ -3431,7 +3692,7 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-network-api"
-version = "1.0.2"
+version = "1.0.4"
 
 [[patch.unused]]
 name = "proxmox-product-config"
@@ -3439,11 +3700,15 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-rest-server"
-version = "1.0.1"
+version = "1.0.3"
 
 [[patch.unused]]
 name = "proxmox-router"
-version = "3.2.2"
+version = "3.2.4"
+
+[[patch.unused]]
+name = "proxmox-s3-client"
+version = "1.2.4"
 
 [[patch.unused]]
 name = "proxmox-shared-memory"
@@ -3451,11 +3716,11 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-simple-config"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-syslog-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-systemd"
@@ -3463,11 +3728,27 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-time-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-worker-task"
 version = "1.0.0"
+
+[[patch.unused]]
+name = "proxmox-yew-comp"
+version = "0.7.12"
+
+[[patch.unused]]
+name = "pve-api-types"
+version = "8.1.4"
+
+[[patch.unused]]
+name = "pwt"
+version = "0.7.8"
+
+[[patch.unused]]
+name = "pwt-macros"
+version = "0.5.0"
 
 [[patch.unused]]
 name = "pxar"

--- a/pkgs/pve-rs/default.nix
+++ b/pkgs/pve-rs/default.nix
@@ -22,12 +22,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-rs";
-    version = "0.11.1";
+    version = "0.11.4";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/proxmox-perl-rs.git";
-      rev = "9f59fe9e71895f3f2348af830fdd76656e139fa4";
-      hash = "sha256-sgWwO44hqH4j56y71yzmOSBQIZMkicsSvmWkLalg2a0=";
+      rev = "284e10f01c1334d37a93ef490435d6622b7a8bdb";
+      hash = "sha256-uZ4u+h5SkRsZNQ0FIAdVQoUjhgZaIfCHtRljZO7g6r4=";
     };
 
     cargoDeps = rustPlatform.importCargoLock {

--- a/pkgs/pve-rs/default.nix
+++ b/pkgs/pve-rs/default.nix
@@ -22,12 +22,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-rs";
-    version = "0.10.10";
+    version = "0.11.1";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/proxmox-perl-rs.git";
-      rev = "f2fbed015ec15d204193bcb751388d8acd3bf6ef";
-      hash = "sha256-4ZROGAeWDaFsULNpuYIJMbqyW8e+eVenzfLNsj4lOYQ=";
+      rev = "9f59fe9e71895f3f2348af830fdd76656e139fa4";
+      hash = "sha256-sgWwO44hqH4j56y71yzmOSBQIZMkicsSvmWkLalg2a0=";
     };
 
     cargoDeps = rustPlatform.importCargoLock {

--- a/pkgs/pve-rs/sources.nix
+++ b/pkgs/pve-rs/sources.nix
@@ -719,7 +719,7 @@
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "391412712c4dd6f86157eb0c3767ef6e36750896";
     
-    sha256 = "sha256-c3Z7LveHM34DNlEcVpFFgP8sQFIDYjPsxO6wdK2RdgE=";
+    sha256 = "00bnj6np9c7fqkn36qh3a902rzw08n8mc72i6q1pwcw7ywp7nxkk";
     crates = [
       {
         name = "proxmox-uuid";

--- a/pkgs/pve-rs/sources.nix
+++ b/pkgs/pve-rs/sources.nix
@@ -3,7 +3,7 @@
     name = "librust-pathpatterns-dev";
     url = "git://git.proxmox.com/git/pathpatterns.git";
     rev = "42e5e96e30297da878a4d4b3a7fa52b65c1be0ab";
-
+    
     sha256 = "0fq2ik07wwd291m1r7z37zajfml15gb1h3gm88my12pn1x723hak";
     crates = [
       {
@@ -15,9 +15,9 @@
   {
     name = "librust-pbs-api-types-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "a3c70d5eb88db31924cd539e0d5f55e77d26af77";
-
-    sha256 = "0lcvdnsa8dks8vv27d6bfk7vai0wnvf8qrc6k29y04xgmnbsz2p7";
+    rev = "8c73b19ca906981be2227ba41b303e819ff59fc5";
+    
+    sha256 = "00byp3dgshwfa47c4mq210r5vlqkylpyk02dlwhjns70k671mfl9";
     crates = [
       {
         name = "pbs-api-types";
@@ -29,7 +29,7 @@
     name = "librust-perlmod-dev";
     url = "git://git.proxmox.com/git/perlmod.git";
     rev = "3f0fcc1f1601bad6ccacd38796865a927d100cda";
-
+    
     sha256 = "1q6zq05dq5awfy50mi6cj374g0lnvy1vi4x4w6sw2c7xphswrr5n";
     crates = [
       {
@@ -42,7 +42,7 @@
     name = "librust-perlmod-macro-dev";
     url = "git://git.proxmox.com/git/perlmod.git";
     rev = "4f946ea4362a5bdbbb131aa71dc6e3b19cb02467";
-
+    
     sha256 = "0rnyd6jhkxacclm342239cvz903fwxgnmy07lwvszyiy0f23im0z";
     crates = [
       {
@@ -54,9 +54,9 @@
   {
     name = "librust-proxmox-access-control-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "160506ea3884d5c38fee29d11dd03a352348d6ad";
-
-    sha256 = "1yl3xhwd8klzrzyr9nbll9sa3b8c4nnbhxcndghqbria5lqjibv1";
+    rev = "6a8354f4b3af0c0f8988e4cfc2b8f6554182e6fc";
+    
+    sha256 = "0jd8rdb6rh7ji4dkdg0d09ihlacwnz5sa4kaqmgdq632f12s43m5";
     crates = [
       {
         name = "proxmox-access-control";
@@ -67,9 +67,9 @@
   {
     name = "librust-proxmox-acme-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "beaadf89ea2b0de080ea99c52cbef04753498a06";
-
-    sha256 = "01v9w2xcc1dijsdgngcngicjjrbm5irc9z011ap8mw37rkfdq7iz";
+    rev = "2383831533bf316ce0dea93205cd263c101452e9";
+    
+    sha256 = "00r7wmcl7fk900939cjc2dmnj2bbv8wjp19gdr500dali1v7mxk9";
     crates = [
       {
         name = "proxmox-acme-api";
@@ -80,9 +80,9 @@
   {
     name = "librust-proxmox-acme-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "e45bcd1cd1f10ce53578dba6db13a68d9fbbd8cf";
-
-    sha256 = "14hr1ixbhnfqcby49rr7cimfj668nglxgiql9hs24j28xf5ha6lj";
+    rev = "039d25dfcfb53b60c641b46fd471c45acc2811e0";
+    
+    sha256 = "00c3mjd223r6x0a8jzdz3j6qrrdixq8r5qyngn4nds1rg0k9vhxw";
     crates = [
       {
         name = "proxmox-acme";
@@ -93,9 +93,9 @@
   {
     name = "librust-proxmox-api-macro-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "478d8b9e8cddf14cdbd5f0d24effe7e30ce3fb84";
-
-    sha256 = "02yxyzx9wzaagifymjncidp3jdv5hxpzqcn8i6c3hj4npjbg26zc";
+    rev = "4defc51c0d5b35d5c503338fe79755436ccfb0e6";
+    
+    sha256 = "1xv198sn5i3k16f9k7irmnyjqz9jjl1n1w1flhjg3r938q17qna7";
     crates = [
       {
         name = "proxmox-api-macro";
@@ -106,9 +106,9 @@
   {
     name = "librust-proxmox-apt-api-types-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "e2305b8f8e610e713b5acb9d90f42a1423abf1d8";
-
-    sha256 = "09ywa6fkk7x10sa3234p3zkbjvsj404a0pqwbq59f1pkn5sd3b59";
+    rev = "d42b3ba3c43ecd3a94467b29f48ae61901d2bebf";
+    
+    sha256 = "1xcnblj6g4snjdbza1vsw4xz9w7qiqa4sjlbh3r6hm3mp3iwza2m";
     crates = [
       {
         name = "proxmox-apt-api-types";
@@ -119,9 +119,9 @@
   {
     name = "librust-proxmox-apt-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "db5b6d35dd163132eb7c497fe1d4b69a7ee7475c";
-
-    sha256 = "14yiqwl33ankk5g7mhykfivgj3fdmarrr7jszs8zrrw519chj0ap";
+    rev = "455b6499f4eda64a7fd5391ebaf9c699d7270dcd";
+    
+    sha256 = "0731ipsnwdzi4wbsl9zy0vbc46iqyh5f4vfpnj6xb8k0sms52jz2";
     crates = [
       {
         name = "proxmox-apt";
@@ -133,7 +133,7 @@
     name = "librust-proxmox-async-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "9820e1ca7694c505b3cb9711f124026e0bb7ea4a";
-
+    
     sha256 = "0inf0iqs8hhz4xanvin0131f8a7ypk4yvfbl3brg6gf2rn6p6rhr";
     crates = [
       {
@@ -145,9 +145,9 @@
   {
     name = "librust-proxmox-auth-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "e917155007a6a246144179e26bda0ebb9b0a426f";
-
-    sha256 = "1gpszwa5wfilgf87zf1d0y6blw037c4j14dcg586l3z6rrnzmaip";
+    rev = "24536125a427eeca1180b9e37e86482e872393ee";
+    
+    sha256 = "06i3lr9yna72xngj8zrkicvn3lfhh73lyqr0ij2qni542d5vim8f";
     crates = [
       {
         name = "proxmox-auth-api";
@@ -159,7 +159,7 @@
     name = "librust-proxmox-base64-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "a5015e9684f62f7dc4f28111dec8971dd33a40d4";
-
+    
     sha256 = "0c3f1dcsh5zz9gq91a1772zxg16vfxpvjnpj0xzkkhl4k57dbryr";
     crates = [
       {
@@ -172,7 +172,7 @@
     name = "librust-proxmox-borrow-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "82beb937ad4308848cb50ab619320d3b553060f9";
-
+    
     sha256 = "1929f28nc5w0asigvrm44wa5i93wmkhyf4zbj754k5xzr14qg8cg";
     crates = [
       {
@@ -184,9 +184,9 @@
   {
     name = "librust-proxmox-client-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "2b21ed67474ac26b57964354445b2b39bdbf4157";
-
-    sha256 = "0ajm4mdxq35rx13vadm3mq6l935nkyvnl5iq6gy4kykr1j718phq";
+    rev = "e60a1caef6ba8f78d8a28310c797ae0c569c014d";
+    
+    sha256 = "0pk8zc6a449r7zflnik14172vbvsa747z66hai43f6sbpz7a47rg";
     crates = [
       {
         name = "proxmox-client";
@@ -197,9 +197,9 @@
   {
     name = "librust-proxmox-compression-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "47719bb5836d23cfebd7904e95e5bf6770d6db4f";
-
-    sha256 = "1ryd3h7nxa7gia9z52ia985gia1dyvhclsjdh4adiyrikbgzccsz";
+    rev = "07aad061ee24502b2bdb4695c1e594b00818d90f";
+    
+    sha256 = "04cbc75bcib1imknw0cmva9awz73nay3mx73vd8msni5q6xdkrn4";
     crates = [
       {
         name = "proxmox-compression";
@@ -210,9 +210,9 @@
   {
     name = "librust-proxmox-config-digest-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "04fa1610da66aa4a3782a28f7d79c1043d4b42ed";
-
-    sha256 = "0nxpm806civ5qx33h1r8qdi6hcxr656pr52d6c3n5ymgknx1h3aj";
+    rev = "6d1bdcbb38fb0358495f404e8cad38231498f1bf";
+    
+    sha256 = "05q2vff5z7ms8vv14l1z690gncmapjc5wxffzsq4vfd2cpbg4ig6";
     crates = [
       {
         name = "proxmox-config-digest";
@@ -224,7 +224,7 @@
     name = "librust-proxmox-daemon-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "de88fc9a481042a1d10164687515f5496c13a762";
-
+    
     sha256 = "1m0rkarpmk2yxl2xkc04adxj4fnz39s09kcqgbd081jh6sv90vq3";
     crates = [
       {
@@ -236,9 +236,9 @@
   {
     name = "librust-proxmox-dns-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "4ea106bee233a996afbc1ce2dff6179f4f13433a";
-
-    sha256 = "08srksgqpx1lqx99npk40imd9s70bms4p3k445h8byxr6znb5rxn";
+    rev = "ad022fe03631d74be151e91ececb9698c55465a8";
+    
+    sha256 = "0bdwrkadk26vb9c14qrmkkcil5ddq8vyhb3wpm1isxax0fwkhbh2";
     crates = [
       {
         name = "proxmox-dns-api";
@@ -249,9 +249,9 @@
   {
     name = "librust-proxmox-frr-dev";
     url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
-    rev = "05b8fc9e7d004e821c7907dc4897b475cf97ac66";
-
-    sha256 = "1y46wpxdkk964h8magz3h4k51z8hqqydnb68316jaamk1jflj9cl";
+    rev = "e36668c887ffd349ca52553254476d1c52a5388b";
+    
+    sha256 = "0nv3nfd2rzw060w3xvlyq035kizj2pmprwk5kx4a9whq3qfaq1s3";
     crates = [
       {
         name = "proxmox-frr";
@@ -262,9 +262,9 @@
   {
     name = "librust-proxmox-http-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "e43876114c5ea1cdbd13456682d91b8a7be02d2b";
-
-    sha256 = "1ms8q65ynj1daqcqv98ylck1a5ski431mlbm1iyns6s9yf1f8mkh";
+    rev = "adb44f2e032755b227b95c089c1d64c026809e18";
+    
+    sha256 = "08bn1j9xvkmj9k1js85wrgj535fp8f29drx574ldlhsdgmicnpd8";
     crates = [
       {
         name = "proxmox-http";
@@ -276,7 +276,7 @@
     name = "librust-proxmox-http-error-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "c54d689db2328803d1c7944311e55bc83805a1fa";
-
+    
     sha256 = "1q39jkgjbn4cd7crvdinpx3z60zz53xyk0rfv10vkp0h46xd8da8";
     crates = [
       {
@@ -288,9 +288,9 @@
   {
     name = "librust-proxmox-human-byte-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "000432028d39633918cc9ae9ced55b5dc5141564";
-
-    sha256 = "0wsc0srrfkaljbb7gb8k0d2p1shrg5zpx415545y2sfc40a50fvm";
+    rev = "07e146b60c147bdfc7a4a1f07f044808078fc4a0";
+    
+    sha256 = "0dd09x76fffdijgqp4pcdy9s5hvir2xfkz30hgxh6wz56dj0pxlq";
     crates = [
       {
         name = "proxmox-human-byte";
@@ -301,9 +301,9 @@
   {
     name = "librust-proxmox-io-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "b04e04b13d835b64abd30e1baf5974023cfcc370";
-
-    sha256 = "1dqi3aqp91ks5np9k4m70s05x57p7jnx63hlsy7871vs7yqvf7f3";
+    rev = "bb3016b84666f707899c36b679c145902510ea1f";
+    
+    sha256 = "1wyn07lbbjxhxv9367gg784jr881jmsdnz1rig9abfhj2p2dn28i";
     crates = [
       {
         name = "proxmox-io";
@@ -315,7 +315,7 @@
     name = "librust-proxmox-lang-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "11076aa817184c94536483fc16e0f653a68b5cf0";
-
+    
     sha256 = "1xml4z38zf03p8md8g0zysyn92klpl93dpafsry4lwmnlripv19b";
     crates = [
       {
@@ -327,9 +327,9 @@
   {
     name = "librust-proxmox-ldap-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3ccba3065a9165ae949eabbd5a3ae08cf018cef7";
-
-    sha256 = "0gz43z36j89mkidsri0hw75y9l244pcf5lbamq44s6d8gdsniz4m";
+    rev = "c13754571eb37e157fa5dc9d21651dc29827459d";
+    
+    sha256 = "03cv9sgxcxmrlk4h4mb072aq4ds44pds07hlh72lrbrp4kjaa7nh";
     crates = [
       {
         name = "proxmox-ldap";
@@ -341,7 +341,7 @@
     name = "librust-proxmox-log-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "4a70ad566609a893451220b2ba0d4451a893e93e";
-
+    
     sha256 = "17sqf08w4qr3i0zpi5psfwlyv7vaxwj7kfa9ibfs0i1sqpzk3cvb";
     crates = [
       {
@@ -353,9 +353,9 @@
   {
     name = "librust-proxmox-login-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "d22a98772c2cea7c49d469255ae1ed2060a10e7d";
-
-    sha256 = "1h8w4xbappq9cvjcgnmfra4snfs2l6323y5bzr7cvz4xi4wfx269";
+    rev = "4eb5517830ae58ca522bfe9f90abac1753579889";
+    
+    sha256 = "1y44rivch5zci1501nazyldy7qkf1n547245y2yy6ikah7s04x9j";
     crates = [
       {
         name = "proxmox-login";
@@ -367,7 +367,7 @@
     name = "librust-proxmox-metrics-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "c6830856f5558b5a812f47d659e817a5543c7976";
-
+    
     sha256 = "0790rzjf12i07i7kiphc3llzj206hbq9argjp6bl1019hxf28ywh";
     crates = [
       {
@@ -379,9 +379,9 @@
   {
     name = "librust-proxmox-network-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "16588a7d07deedfe84433837ca90743e23c8ad3b";
-
-    sha256 = "13rdix51vmsc31xhmgkjyy5x1jy5anr46p8kk779dcn6j01453b3";
+    rev = "55ecc70c85986dd7d692a42284a96f977ff732b6";
+    
+    sha256 = "10j35q04ma464glxlmh7pvlnk1ysnk71kvda4k9a5hvd4sfmns36";
     crates = [
       {
         name = "proxmox-network-api";
@@ -392,9 +392,9 @@
   {
     name = "librust-proxmox-network-types-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "ffe61b2cc31de6592be8129aadba5918dd9d4911";
-
-    sha256 = "1gv3krnvdpjwl4gfgvdjvhrpxcdc5dwzdrvrjk3by0mmvlc9dp3f";
+    rev = "b2e044225ba078a892e80405f424f25f9518417b";
+    
+    sha256 = "1mm6lfnrji5gxlsa591gswcjdn5wh3g48f84d7n6lh42g5ibb3ks";
     crates = [
       {
         name = "proxmox-network-types";
@@ -405,9 +405,9 @@
   {
     name = "librust-proxmox-notify-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "43e3a6ca48e1352e2c20cf8616915a31a9ad8c10";
-
-    sha256 = "0rn1jaymr50vgqpbbg604kgq03wqg7zjclx6g9ab5y7jb59av9i7";
+    rev = "52b04982627911d4d7255bd25c78d7eb4d695bcf";
+    
+    sha256 = "1xaamw59agm1dcphz2hpl46x8xpavl8vjjnjzrkqzm67vh3zrshp";
     crates = [
       {
         name = "proxmox-notify";
@@ -416,10 +416,23 @@
     ];
   }
   {
+    name = "librust-proxmox-oci-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "56e0f959d8d906d169b1302920e96ca644692628";
+    
+    sha256 = "0k8pywhnnpz67k9qaks68g57pdrn5vzw9aabzrni4ph435zarq72";
+    crates = [
+      {
+        name = "proxmox-oci";
+        path = "proxmox-oci";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-openid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "cddc6b525b92cea57694297fba678d49e348ba8a";
-
+    
     sha256 = "1wkrs2xid9wfzv4i9r0kpcdrxhr8rhlp5hwyzbjvm2vi50h0d0jl";
     crates = [
       {
@@ -432,7 +445,7 @@
     name = "librust-proxmox-product-config-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "d42d5038bc4998200d18c9d190b9b013d6522722";
-
+    
     sha256 = "1dsjziab9d8lm34fdd4fh2rjm6xz3fas6rwaya0gzc8dwmvn4ar2";
     crates = [
       {
@@ -444,9 +457,9 @@
   {
     name = "librust-proxmox-resource-scheduling-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "5625354accdede10680287257d959e135b6742d0";
-
-    sha256 = "02bh82r3yccvgydvpi23k8nh0r2wn3503ji0z35fl5npb7ayzvsk";
+    rev = "69d1fddb642a2a102095cfa10e41ef10abc8a5e6";
+    
+    sha256 = "1ag2j6rb89321wps1isxjnyj8hr45hxrgx1jh84k19kj8322vrfb";
     crates = [
       {
         name = "proxmox-resource-scheduling";
@@ -457,9 +470,9 @@
   {
     name = "librust-proxmox-rest-server-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "03a7d59ac477f804c7acfbc1d4f4f8351715b852";
-
-    sha256 = "1zhccvksqywdnqrjgjyhrbhrbbm13sv1yhkp6k3cxa1a0273a0sc";
+    rev = "9c04287c6a38fb00e85aa00935279e8aeb68c993";
+    
+    sha256 = "0daip10frbg79ks453qlrj197lhg2j5351yrc2mg5jgn2jh79z3r";
     crates = [
       {
         name = "proxmox-rest-server";
@@ -470,9 +483,9 @@
   {
     name = "librust-proxmox-router-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "35c28da99fc02a8f9de3e010ccac3dc8167e8c31";
-
-    sha256 = "1a51xxz9l5gs02dyxhx1zcc1733j543n04xnx5557cxbyfcj5d9h";
+    rev = "99c6d274aa41dd09d49bf9b6947df05c209ca8f9";
+    
+    sha256 = "0h9qhi6gc1gjm8i2w2faahw91y6aagnian54scp0mh1mwi195dry";
     crates = [
       {
         name = "proxmox-router";
@@ -481,11 +494,24 @@
     ];
   }
   {
+    name = "librust-proxmox-s3-client-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "1a4e322d59debc6ba7d748ccb43236ce43c41741";
+    
+    sha256 = "1nizs8bmsghldsfxrpg4m7iqjm2y2nm41q0pli7l8ranwm9fy870";
+    crates = [
+      {
+        name = "proxmox-s3-client";
+        path = "proxmox-s3-client";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-schema-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "c404bcbe16f5b9bab5ddea06d2b1274fae0667c3";
-
-    sha256 = "0h4c8i9aya8m429vadafjhvghv2lvphiwy4fypyd55lw02hi4cnb";
+    rev = "ed34cf12938cf9f78162ba5a2d98956b416a8883";
+    
+    sha256 = "0qk5jzlp8ks9gpaya88hs1v7slrhswxbwd023kkc8wg92bb1g7ir";
     crates = [
       {
         name = "proxmox-schema";
@@ -496,9 +522,9 @@
   {
     name = "librust-proxmox-sdn-types-dev";
     url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
-    rev = "f662e9221b1705c1660ef14257c7c54fd10101ab";
-
-    sha256 = "0v2mffg4wcjyppxanyxzvgsc4l90milivni4x31c8lhsb0k5gddc";
+    rev = "17af874c77f767323a0cf19ef1345f9910ccb5ff";
+    
+    sha256 = "187g9sy767qh8hzmj3ydcys5b3i2di2dnbvrpkzm0h0g3xskk2q0";
     crates = [
       {
         name = "proxmox-sdn-types";
@@ -509,9 +535,9 @@
   {
     name = "librust-proxmox-section-config-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "61b5788a639e3e74f85666f8c240d6b37acdf9fa";
-
-    sha256 = "0w8zggdf9dcfbk8f11ipq50z0id9fab0jadsrjn8vw1w5gh5rwf9";
+    rev = "2a375fa97ea361fb7b2c283b754478a1a6e791c7";
+    
+    sha256 = "1f3rlcf8w0zfdn3znah79k3f55rqjvrg2k0w02klsr7knqv8s050";
     crates = [
       {
         name = "proxmox-section-config";
@@ -522,9 +548,9 @@
   {
     name = "librust-proxmox-sendmail-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "f03e6651032acce45246f49a6bc6bc1f0794244b";
-
-    sha256 = "098px04lajing8pypax7lqardafdzsm9ikpg8qdcwx7p1qhsnjvy";
+    rev = "13340ae4452f8e07d2b35769233914ab8cb84192";
+    
+    sha256 = "1yafbqafwv7bjgc414p6vm6hiy0fwb53sh9wsp2l3m83i5ixx464";
     crates = [
       {
         name = "proxmox-sendmail";
@@ -535,9 +561,9 @@
   {
     name = "librust-proxmox-serde-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "521ebf5bf0160f7a8843d363073ebb9e21d101c1";
-
-    sha256 = "0mwsdg7j6xa1nlvgnqqlpw49vazs399f2m3c4g5p08hx39wvlhzv";
+    rev = "84ee8f4e5d825625a3d957b341f5c55cca1e4b32";
+    
+    sha256 = "06ygg8j5h466k0hvbbf0323abjcv7j72qxn2vkvfxxb7dygagwsd";
     crates = [
       {
         name = "proxmox-serde";
@@ -549,7 +575,7 @@
     name = "librust-proxmox-shared-cache-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "d23c49fe82b9bd7a15c7c58585be443116f3045a";
-
+    
     sha256 = "151czqr9v08vqp2jfgdbc79fbq5v7jpyhifzn244zrvmklpgsmiv";
     crates = [
       {
@@ -562,7 +588,7 @@
     name = "librust-proxmox-shared-memory-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "eb1116c1e3fd27e391a9dde487eabc673368a6c5";
-
+    
     sha256 = "0gccrgy2qlggqwhb42zkypn8bdg05xxd62g4gaz9mzc1wby9bk34";
     crates = [
       {
@@ -574,9 +600,9 @@
   {
     name = "librust-proxmox-simple-config-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "c273e86e0cef266e11ccfe2d2522e79173ffdaff";
-
-    sha256 = "1zma7rj7ksl0n5msnwbi195kkxchj3ax9h5fg3q8v5v70dmv8vv9";
+    rev = "35587a12af4197fb8243c9239a27302d2fc283b8";
+    
+    sha256 = "1f81702jxdi9mxbrix4fsq71aw5nmj41myi6y45cimx1lm49gpdg";
     crates = [
       {
         name = "proxmox-simple-config";
@@ -588,7 +614,7 @@
     name = "librust-proxmox-sortable-macro-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "a1766995b589c5668a7f9d4f0b15e6fbe32b6a36";
-
+    
     sha256 = "1p1q732ni8cmx3hckac01q93y1bq2qrpr0zgigwq095gg6xik680";
     crates = [
       {
@@ -600,9 +626,9 @@
   {
     name = "librust-proxmox-subscription-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "5f641e5a99e89d52ccdde500d79ce2c0d6dea71a";
-
-    sha256 = "1s249m4z776czzbhi0s4a8vshh2p7pw305iqxfsjnk06ii6zghnf";
+    rev = "7c2a07e69b42b73e149489027409932af623ef94";
+    
+    sha256 = "1mkm2wvpr7nn03b9f2kxlylwi2sf8nyynk3kjy10aam8x1kdnxa7";
     crates = [
       {
         name = "proxmox-subscription";
@@ -614,7 +640,7 @@
     name = "librust-proxmox-sys-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "4919e03d9bd2b6b0be914667eedcff81e727ab12";
-
+    
     sha256 = "1990ywrlzd9jiliskcha96kmqbdlw6bcwixyjsdnm8kpnc8rrxzk";
     crates = [
       {
@@ -626,9 +652,9 @@
   {
     name = "librust-proxmox-syslog-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "b79913168ac606619b4934a614dcfc83cc6833ee";
-
-    sha256 = "1q3z4csi2l2m1bppk9rv7hmf9mlwsvfa7a7c3iil0c9ws3767x0d";
+    rev = "7440ea15b3a70fe4b00a4986957dfd031053ac14";
+    
+    sha256 = "08ysn6z0cfcic9w0xcpm9a590ry4dd60n3gs2c9nj5n81gz06rr8";
     crates = [
       {
         name = "proxmox-syslog-api";
@@ -640,7 +666,7 @@
     name = "librust-proxmox-systemd-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "fb3e8ca768c5c815fc55ca78e095df35a1c06d78";
-
+    
     sha256 = "1lblv6sw4rrwf1xha3hz727mwas90zqykx9nwrw60s0sabw5pyic";
     crates = [
       {
@@ -652,9 +678,9 @@
   {
     name = "librust-proxmox-tfa-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "7de539b26cbca1bdc2a24f3591e59469d95746e1";
-
-    sha256 = "0x4nvz5ysxh0s0dgf86salac086b25apsllgqisb379670wfn9gn";
+    rev = "320f2f0c600b03829bfe534ea4bed4730122dad0";
+    
+    sha256 = "01dnv4jcagpv8vkajm98l1bml3z8w5sj2p214y94l4915j7991xm";
     crates = [
       {
         name = "proxmox-tfa";
@@ -665,9 +691,9 @@
   {
     name = "librust-proxmox-time-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3d8d38799e403e069679aa942565d95bc65b48fe";
-
-    sha256 = "0ga8zp7kqvlzvjal9zgwi4qx7nj0grjg0a9xb9ll6anx08si0jac";
+    rev = "3db314886689109607ff9756fff04c4710e2c410";
+    
+    sha256 = "072f7b3pabkkhf7v349n2ns99xhqlamzs7wvhipgbz354rv62q42";
     crates = [
       {
         name = "proxmox-time-api";
@@ -679,7 +705,7 @@
     name = "librust-proxmox-time-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "a79ccc19071ad69ee419a58f38577216182ffbaa";
-
+    
     sha256 = "1kl0syqwf59654i43hm4ca0l124wixl43mlvhhj9p2j81iydyyzn";
     crates = [
       {
@@ -691,9 +717,9 @@
   {
     name = "librust-proxmox-uuid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "aced6d2b7d8c47e1a5825d825ac988eac7d90c8a";
-
-    sha256 = "01famhymykh5l99iq5gg6rifbfn8gwxpi4zlpnihbiv83kqx6xvc";
+    rev = "391412712c4dd6f86157eb0c3767ef6e36750896";
+    
+    sha256 = "sha256-c3Z7LveHM34DNlEcVpFFgP8sQFIDYjPsxO6wdK2RdgE=";
     crates = [
       {
         name = "proxmox-uuid";
@@ -704,9 +730,9 @@
   {
     name = "librust-proxmox-ve-config-dev";
     url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
-    rev = "587c67fdb139463a5e6218dd17d1cd442babe9b5";
-
-    sha256 = "1xdnkcya5xi09gddf5y197bz9mvyxz6crdrq4xhwqavc3p6bvwv1";
+    rev = "4f236d3ce6aa882158bfc01a5cf86d87632542df";
+    
+    sha256 = "1py4rr61rrpmavphhibc7nq6764kiy4q9cns0s38sjgrfd9fphfw";
     crates = [
       {
         name = "proxmox-ve-config";
@@ -718,7 +744,7 @@
     name = "librust-proxmox-worker-task-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "b7292443a12b2f0c43b5d4e9bee6334e0e6241ff";
-
+    
     sha256 = "1q0pvx1vrhpva2n7ykvpzgch735c7vhg5lvb4n6946l33dn0cyna";
     crates = [
       {
@@ -728,10 +754,62 @@
     ];
   }
   {
+    name = "librust-proxmox-yew-comp-dev";
+    url = "git://git.proxmox.com/git/ui/proxmox-yew-comp.git";
+    rev = "f967b2341685536a53463137ad7c027ebc68e3e8";
+    
+    sha256 = "0z623af4xjczxpkxgblzr95rmgfn2b8cg22kc4vvccdhh5qbfmlz";
+    crates = [
+      {
+        name = "proxmox-yew-comp";
+        path = ".";
+      }
+    ];
+  }
+  {
+    name = "librust-pve-api-types-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "162d6095dda6e49a84ff205ad088b8a02a970a85";
+    
+    sha256 = "0khrp58wcn3bchf3v5mh56pc5zh4rprqad7xf48rqdm4x864jw15";
+    crates = [
+      {
+        name = "pve-api-types";
+        path = "pve-api-types";
+      }
+    ];
+  }
+  {
+    name = "librust-pwt-dev";
+    url = "git://git.proxmox.com/git/ui/proxmox-yew-widget-toolkit.git";
+    rev = "d6ed68117198ca602f75d5f72744c5c069a666ba";
+    
+    sha256 = "1nzxxhc02l8wxlanz2ik1d9v26w5ynad7s31vimzd0w299qjw9cg";
+    crates = [
+      {
+        name = "pwt";
+        path = ".";
+      }
+    ];
+  }
+  {
+    name = "librust-pwt-macros-dev";
+    url = "git://git.proxmox.com/git/ui/proxmox-yew-widget-toolkit.git";
+    rev = "23d4a1627b2cd89e97cba561a0824a2891b41452";
+    
+    sha256 = "0zjzh1iclb6gcidn5csxbbgdsz84s9mdgr4bv636ppchfa5j2vjv";
+    crates = [
+      {
+        name = "pwt-macros";
+        path = "pwt-macros";
+      }
+    ];
+  }
+  {
     name = "librust-pxar-dev";
     url = "git://git.proxmox.com/git/pxar.git";
     rev = "993c66fcb8819770f279cb9fb4d13f58f367606c";
-
+    
     sha256 = "1bqfdq15kq45wrqmsh559ijbv48k73fjca5l4198mflgii6f942p";
     crates = [
       {

--- a/pkgs/pve-storage/default.nix
+++ b/pkgs/pve-storage/default.nix
@@ -24,7 +24,7 @@
   rpcbind,
   samba,
   smartmontools,
-  targetcli,
+  targetcli-fb,
   util-linux,
   zfs,
   posixstrptime,
@@ -49,12 +49,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-storage";
-    version = "9.0.13";
+    version = "9.0.17";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "609752f3ae371537b65484caeee14d3ed1569743";
-      hash = "sha256-672k/ll1tw0N2ulOGFohIR0c83Q5NaZsdtrJWP5TmQU=";
+      rev = "60a80163e05500ebf40dffa1a4df681723cf346c";
+      hash = "sha256-jJw7/3QpKr670PtkQS2Cele/W3rJZ9sFKZ6mPMF3GGo=";
     };
 
     sourceRoot = "${src.name}/src";
@@ -112,7 +112,7 @@ perl540.pkgs.toPerlModule (
         -e "s|/usr/bin/scp|${openssh}/bin/scp|" \
         -e "s|/usr/bin/smbclient|${samba}/bin/smbclient|" \
         -e "s|/usr/bin/ssh|${openssh}/bin/ssh|" \
-        -e "s|/usr/bin/targetcli|${targetcli}/bin/targetcli|" \
+        -e "s|/usr/bin/targetcli|${targetcli-fb}/bin/targetcli|" \
         -e "s|/usr/bin/vma|${pve-qemu}/bin/vma|" \
         -e "s|/usr/bin/zcat|${gzip}/bin/zcat|" \
         -e "s|/usr/libexec/ceph|$out/libexec/ceph|" \

--- a/pkgs/pve-storage/default.nix
+++ b/pkgs/pve-storage/default.nix
@@ -49,12 +49,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-storage";
-    version = "9.0.17";
+    version = "9.1.0";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "60a80163e05500ebf40dffa1a4df681723cf346c";
-      hash = "sha256-jJw7/3QpKr670PtkQS2Cele/W3rJZ9sFKZ6mPMF3GGo=";
+      rev = "6f49432acc6d030017c5f8833a17b33c6ae00324";
+      hash = "sha256-jyDunxby8WPR3BnqdmbOVbHKOERwchhsEb4WYo0j2q8=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-update/pve_update/mappings.json
+++ b/pkgs/pve-update/pve_update/mappings.json
@@ -360,5 +360,10 @@
     "package_name": "proxmox-node-status",
     "debian_package_name": "librust-proxmox-node-status-dev",
     "git_repository": "git://git.proxmox.com/git/proxmox.git"
+  },
+  {
+    "package_name": "proxmox-oci",
+    "debian_package_name": "librust-proxmox-oci-dev",
+    "git_repository": "git://git.proxmox.com/git/proxmox.git"
   }
 ]

--- a/pkgs/pve-xtermjs/default.nix
+++ b/pkgs/pve-xtermjs/default.nix
@@ -5,14 +5,14 @@
   pve-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "pve-xtermjs";
-  version = "5.5.0-2";
+  version = "5.5.0-3";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/pve-xtermjs.git";
-    rev = "a29b36079fbaf18586615e26bb615992d1007c7e";
-    hash = "sha256-89K93D8uD1pAynM1M3ixbbZS3p7Sxga9OA/HgpVBeHY=";
+    rev = "222b38aa8f226146d236a7f5f82744d03a8557df";
+    hash = "sha256-OunLO3sGkpF7nbB0pNP4zTcxT1xHR7j/J0ZaV7UJhug=";
   };
 
   dontBuild = true;

--- a/pkgs/pve-yew-mobile-gui/Cargo.lock
+++ b/pkgs/pve-yew-mobile-gui/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -31,7 +31,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -63,9 +63,9 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -75,9 +75,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cfg-if"
@@ -134,7 +134,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -278,7 +278,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -690,14 +690,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hermit-abi"
@@ -733,12 +733,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -749,7 +748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -760,16 +759,16 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -780,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -793,11 +792,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -808,42 +806,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -889,14 +883,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "699c1b6d335e63d0ba5c1e1c7f647371ce989c3bcbe1f7ed2b85fa56e3bd1a21"
 dependencies = [
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -904,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
@@ -926,21 +920,21 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -981,6 +975,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "pbs-api-types"
+version = "1.0.6"
+dependencies = [
+ "anyhow",
+ "const_format",
+ "hex",
+ "percent-encoding",
+ "proxmox-apt-api-types",
+ "proxmox-auth-api",
+ "proxmox-human-byte",
+ "proxmox-lang",
+ "proxmox-s3-client",
+ "proxmox-schema",
+ "proxmox-serde",
+ "proxmox-time",
+ "proxmox-uuid",
+ "regex",
+ "serde",
+ "serde_plain",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,7 +1019,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1031,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -1045,7 +1061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1084,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1110,13 +1126,14 @@ dependencies = [
 
 [[package]]
 name = "proxmox-access-control"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "const_format",
  "proxmox-auth-api",
  "proxmox-schema",
  "proxmox-time",
+ "proxmox-uuid",
  "regex",
  "serde",
  "serde_plain",
@@ -1124,17 +1141,27 @@ dependencies = [
 
 [[package]]
 name = "proxmox-api-macro"
-version = "1.4.1"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "proxmox-apt-api-types"
+version = "2.0.2"
+dependencies = [
+ "proxmox-config-digest",
+ "proxmox-schema",
+ "serde",
+ "serde_plain",
 ]
 
 [[package]]
 name = "proxmox-auth-api"
-version = "1.0.3"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1158,7 +1185,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "hex",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body-util",
  "percent-encoding",
  "proxmox-login",
@@ -1168,8 +1195,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proxmox-config-digest"
+version = "1.0.1"
+dependencies = [
+ "anyhow",
+ "hex",
+ "proxmox-schema",
+ "serde",
+ "serde_plain",
+]
+
+[[package]]
 name = "proxmox-human-byte"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "proxmox-schema",
@@ -1178,10 +1216,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "proxmox-lang"
+version = "1.5.0"
+
+[[package]]
 name = "proxmox-login"
-version = "1.0.1"
+version = "1.0.3"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "js-sys",
  "percent-encoding",
  "proxmox-base64",
@@ -1191,8 +1233,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proxmox-node-status"
+version = "1.0.0"
+dependencies = [
+ "proxmox-schema",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "proxmox-s3-client"
+version = "1.2.3"
+dependencies = [
+ "anyhow",
+ "const_format",
+ "proxmox-schema",
+ "proxmox-serde",
+ "regex",
+ "serde",
+ "serde_plain",
+]
+
+[[package]]
 name = "proxmox-schema"
-version = "4.1.1"
+version = "5.0.1"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1205,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-serde"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "proxmox-base64",
@@ -1216,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "proxmox-tfa"
-version = "6.0.3"
+version = "6.0.4"
 dependencies = [
  "proxmox-schema",
  "serde",
@@ -1239,11 +1303,12 @@ name = "proxmox-uuid"
 version = "1.1.0"
 dependencies = [
  "js-sys",
+ "serde",
 ]
 
 [[package]]
 name = "proxmox-yew-comp"
-version = "0.5.8"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "derivative",
@@ -1252,10 +1317,11 @@ dependencies = [
  "gloo-timers 0.3.0",
  "gloo-utils 0.2.0",
  "html-escape",
- "http 1.3.1",
+ "http 1.4.0",
  "indexmap",
  "js-sys",
  "log",
+ "pbs-api-types",
  "percent-encoding",
  "proxmox-access-control",
  "proxmox-auth-api",
@@ -1263,10 +1329,13 @@ dependencies = [
  "proxmox-client",
  "proxmox-human-byte",
  "proxmox-login",
+ "proxmox-node-status",
  "proxmox-schema",
+ "proxmox-serde",
  "proxmox-tfa",
  "proxmox-time",
  "pulldown-cmark",
+ "pve-api-types",
  "pwt",
  "pwt-macros",
  "qrcode",
@@ -1305,7 +1374,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pve-api-types"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1320,27 +1389,34 @@ dependencies = [
 
 [[package]]
 name = "pve-yew-mobile-gui"
-version = "0.6.2"
+version = "0.6.4"
 dependencies = [
  "anyhow",
+ "derivative",
  "gloo-timers 0.3.0",
  "gloo-utils 0.2.0",
+ "indexmap",
  "js-sys",
  "lazy_static",
  "log",
  "percent-encoding",
+ "proxmox-apt-api-types",
+ "proxmox-base64",
  "proxmox-client",
  "proxmox-human-byte",
  "proxmox-login",
  "proxmox-schema",
+ "proxmox-serde",
  "proxmox-time",
  "proxmox-uuid",
  "proxmox-yew-comp",
  "pve-api-types",
  "pwt",
  "pwt-macros",
+ "regex",
  "serde",
  "serde_json",
+ "serde_plain",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1352,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "pwt"
-version = "0.6.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "derivative",
@@ -1382,11 +1458,11 @@ dependencies = [
 
 [[package]]
 name = "pwt-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1397,9 +1473,9 @@ checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1447,9 +1523,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "serde"
@@ -1500,20 +1576,20 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1574,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1591,7 +1667,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1622,14 +1698,14 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1637,18 +1713,18 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "pin-project-lite",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1674,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1685,35 +1761,35 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-linebreak"
@@ -1735,9 +1811,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1753,9 +1829,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8_iter"
@@ -1798,7 +1874,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -1833,7 +1909,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1876,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yew"
@@ -1917,7 +1993,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1947,16 +2023,15 @@ checksum = "42bfd190a07ca8cfde7cd4c52b3ac463803dc07323db8c34daa697e86365978c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -1964,13 +2039,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -1991,15 +2066,15 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2008,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2019,22 +2094,24 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
 
 [[patch.unused]]
 name = "pathpatterns"
 version = "1.0.0"
-
-[[patch.unused]]
-name = "pbs-api-types"
-version = "1.0.3"
 
 [[patch.unused]]
 name = "perlmod"
@@ -2046,19 +2123,15 @@ version = "0.10.0"
 
 [[patch.unused]]
 name = "proxmox-acme"
-version = "1.0.2"
+version = "1.0.3"
 
 [[patch.unused]]
 name = "proxmox-acme-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-apt"
-version = "0.99.2"
-
-[[patch.unused]]
-name = "proxmox-apt-api-types"
-version = "2.0.0"
+version = "0.99.5"
 
 [[patch.unused]]
 name = "proxmox-async"
@@ -2070,11 +2143,7 @@ version = "1.1.0"
 
 [[patch.unused]]
 name = "proxmox-compression"
-version = "1.0.0"
-
-[[patch.unused]]
-name = "proxmox-config-digest"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-daemon"
@@ -2082,15 +2151,15 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-dns-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-frr"
-version = "0.1.0"
+version = "0.2.0"
 
 [[patch.unused]]
 name = "proxmox-http"
-version = "1.0.2"
+version = "1.0.4"
 
 [[patch.unused]]
 name = "proxmox-http-error"
@@ -2098,15 +2167,11 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-io"
-version = "1.2.0"
-
-[[patch.unused]]
-name = "proxmox-lang"
-version = "1.5.0"
+version = "1.2.1"
 
 [[patch.unused]]
 name = "proxmox-ldap"
-version = "1.0.0"
+version = "1.1.0"
 
 [[patch.unused]]
 name = "proxmox-log"
@@ -2118,19 +2183,19 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-network-api"
-version = "1.0.2"
+version = "1.0.4"
 
 [[patch.unused]]
 name = "proxmox-network-types"
-version = "0.1.1"
-
-[[patch.unused]]
-name = "proxmox-node-status"
-version = "1.0.0"
+version = "0.1.2"
 
 [[patch.unused]]
 name = "proxmox-notify"
-version = "1.0.2"
+version = "1.0.3"
+
+[[patch.unused]]
+name = "proxmox-oci"
+version = "0.2.0"
 
 [[patch.unused]]
 name = "proxmox-openid"
@@ -2142,31 +2207,27 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-resource-scheduling"
-version = "1.0.0"
-
-[[patch.unused]]
-name = "proxmox-rest-server"
 version = "1.0.1"
 
 [[patch.unused]]
-name = "proxmox-router"
-version = "3.2.2"
+name = "proxmox-rest-server"
+version = "1.0.2"
 
 [[patch.unused]]
-name = "proxmox-s3-client"
-version = "1.2.3"
+name = "proxmox-router"
+version = "3.2.3"
 
 [[patch.unused]]
 name = "proxmox-sdn-types"
-version = "0.1.0"
+version = "0.1.1"
 
 [[patch.unused]]
 name = "proxmox-section-config"
-version = "3.1.0"
+version = "3.1.1"
 
 [[patch.unused]]
 name = "proxmox-sendmail"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-shared-cache"
@@ -2178,7 +2239,7 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-simple-config"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-sortable-macro"
@@ -2186,7 +2247,7 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-subscription"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-sys"
@@ -2194,7 +2255,7 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-syslog-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-systemd"
@@ -2202,19 +2263,15 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-time-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-ve-config"
-version = "0.4.2"
+version = "0.4.6"
 
 [[patch.unused]]
 name = "proxmox-worker-task"
 version = "1.0.0"
-
-[[patch.unused]]
-name = "pve-api-types"
-version = "8.1.0"
 
 [[patch.unused]]
 name = "pxar"

--- a/pkgs/pve-yew-mobile-gui/default.nix
+++ b/pkgs/pve-yew-mobile-gui/default.nix
@@ -25,32 +25,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pve-yew-mobile-gui";
-  version = "0.6.2";
+  version = "0.6.4";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/ui/pve-yew-mobile-gui.git";
-    rev = "0d645b23ae2f733d0be7f6aab0fbe09e41096e1b";
-    hash = "sha256-UnhPBJwzsBFidPkNzjC1R+vuU6QYAJok//I07cCEJXY=";
-
-    # FIXME: remove patching submodule address after upgrading to 0.6.3+
-    fetchSubmodules = false;
-    leaveDotGit = true;
-
-    postFetch = ''
-      pushd $out
-      git reset
-      substituteInPlace ./.gitmodules \
-        --replace-fail 'gitolite3@proxdev.maurer-it.com:yew/proxmox-yew-widget-toolkit-assets' \
-                       'git://git.proxmox.com/git/ui/proxmox-yew-widget-toolkit-assets.git' \
-        --replace-fail 'gitolite3@proxdev.maurer-it.com:/rust/proxmox-api-types' \
-                       'git://git.proxmox.com/git/proxmox-api-types.git'
-
-      git submodule update --init --recursive -j ''${NIX_BUILD_CORES:-1} --depth 1
-      # Remove .git dirs
-      find . -name .git -type f -exec rm -rf {} +
-      rm -rf .git/
-      popd
-    '';
+    rev = "c0c8d4863387c28fa8db2c31ce65779bbaf39318";
+    hash = "sha256-EE73KfzXgcI9n5bkC1tAo2EVWGpIk/FzXJjkEDDMZ6E=";
+    fetchSubmodules = true;
   };
 
   cargoDeps = rustPlatform.importCargoLock {

--- a/pkgs/pve-yew-mobile-gui/sources.nix
+++ b/pkgs/pve-yew-mobile-gui/sources.nix
@@ -3,7 +3,7 @@
     name = "librust-pathpatterns-dev";
     url = "git://git.proxmox.com/git/pathpatterns.git";
     rev = "42e5e96e30297da878a4d4b3a7fa52b65c1be0ab";
-
+    
     sha256 = "0fq2ik07wwd291m1r7z37zajfml15gb1h3gm88my12pn1x723hak";
     crates = [
       {
@@ -15,9 +15,9 @@
   {
     name = "librust-pbs-api-types-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "a3c70d5eb88db31924cd539e0d5f55e77d26af77";
-
-    sha256 = "0lcvdnsa8dks8vv27d6bfk7vai0wnvf8qrc6k29y04xgmnbsz2p7";
+    rev = "1ca670858e0494f932c38e34caaca9acfdff4e31";
+    
+    sha256 = "086dp1kjk16v127mqxcx0zz25r1b5bjpm3mssid1nddx2sxlxwin";
     crates = [
       {
         name = "pbs-api-types";
@@ -29,7 +29,7 @@
     name = "librust-perlmod-dev";
     url = "git://git.proxmox.com/git/perlmod.git";
     rev = "3f0fcc1f1601bad6ccacd38796865a927d100cda";
-
+    
     sha256 = "1q6zq05dq5awfy50mi6cj374g0lnvy1vi4x4w6sw2c7xphswrr5n";
     crates = [
       {
@@ -42,7 +42,7 @@
     name = "librust-perlmod-macro-dev";
     url = "git://git.proxmox.com/git/perlmod.git";
     rev = "4f946ea4362a5bdbbb131aa71dc6e3b19cb02467";
-
+    
     sha256 = "0rnyd6jhkxacclm342239cvz903fwxgnmy07lwvszyiy0f23im0z";
     crates = [
       {
@@ -54,9 +54,9 @@
   {
     name = "librust-proxmox-access-control-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "56c4deb6309c41ff5afa5765b112be967c653857";
-
-    sha256 = "0jdy5c1p554zfl7qngha8cyax1mqpwvg1nqjqjy5bcx2cmysyhcs";
+    rev = "ea795fad2924131a323408ac8cdc62126d9e4d8d";
+    
+    sha256 = "0762si4sxby6s0z7csfz3386pybddm22zgs7sh11i4553j56rpjm";
     crates = [
       {
         name = "proxmox-access-control";
@@ -67,9 +67,9 @@
   {
     name = "librust-proxmox-acme-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "beaadf89ea2b0de080ea99c52cbef04753498a06";
-
-    sha256 = "01v9w2xcc1dijsdgngcngicjjrbm5irc9z011ap8mw37rkfdq7iz";
+    rev = "2383831533bf316ce0dea93205cd263c101452e9";
+    
+    sha256 = "00r7wmcl7fk900939cjc2dmnj2bbv8wjp19gdr500dali1v7mxk9";
     crates = [
       {
         name = "proxmox-acme-api";
@@ -80,9 +80,9 @@
   {
     name = "librust-proxmox-acme-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "e45bcd1cd1f10ce53578dba6db13a68d9fbbd8cf";
-
-    sha256 = "14hr1ixbhnfqcby49rr7cimfj668nglxgiql9hs24j28xf5ha6lj";
+    rev = "039d25dfcfb53b60c641b46fd471c45acc2811e0";
+    
+    sha256 = "00c3mjd223r6x0a8jzdz3j6qrrdixq8r5qyngn4nds1rg0k9vhxw";
     crates = [
       {
         name = "proxmox-acme";
@@ -93,9 +93,9 @@
   {
     name = "librust-proxmox-api-macro-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "478d8b9e8cddf14cdbd5f0d24effe7e30ce3fb84";
-
-    sha256 = "02yxyzx9wzaagifymjncidp3jdv5hxpzqcn8i6c3hj4npjbg26zc";
+    rev = "582bbf07f097db2984ed95e680cab0674a476acb";
+    
+    sha256 = "0ddgk6iv6vzpf2wh4qzqbk3vf3dagqczhv0mr2wvgc5i1k0acsqr";
     crates = [
       {
         name = "proxmox-api-macro";
@@ -106,9 +106,9 @@
   {
     name = "librust-proxmox-apt-api-types-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "e2305b8f8e610e713b5acb9d90f42a1423abf1d8";
-
-    sha256 = "09ywa6fkk7x10sa3234p3zkbjvsj404a0pqwbq59f1pkn5sd3b59";
+    rev = "88183452e3b6d86bd8f9e03d222d5c8d1d8a0058";
+    
+    sha256 = "1yqhxkjv69w2fdmm27z7ywffnvy1z1mkq49qc36fj0ivgccv2af3";
     crates = [
       {
         name = "proxmox-apt-api-types";
@@ -119,9 +119,9 @@
   {
     name = "librust-proxmox-apt-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "db5b6d35dd163132eb7c497fe1d4b69a7ee7475c";
-
-    sha256 = "14yiqwl33ankk5g7mhykfivgj3fdmarrr7jszs8zrrw519chj0ap";
+    rev = "6bcbf092768887f7d5d7036b76723f5bd20aec7f";
+    
+    sha256 = "0r4mi2vlg3wlbv9539v42rikn92d9zndmskkk0m7ad5xid7c4nz9";
     crates = [
       {
         name = "proxmox-apt";
@@ -133,7 +133,7 @@
     name = "librust-proxmox-async-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "9820e1ca7694c505b3cb9711f124026e0bb7ea4a";
-
+    
     sha256 = "0inf0iqs8hhz4xanvin0131f8a7ypk4yvfbl3brg6gf2rn6p6rhr";
     crates = [
       {
@@ -145,9 +145,9 @@
   {
     name = "librust-proxmox-auth-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "e917155007a6a246144179e26bda0ebb9b0a426f";
-
-    sha256 = "1gpszwa5wfilgf87zf1d0y6blw037c4j14dcg586l3z6rrnzmaip";
+    rev = "24536125a427eeca1180b9e37e86482e872393ee";
+    
+    sha256 = "06i3lr9yna72xngj8zrkicvn3lfhh73lyqr0ij2qni542d5vim8f";
     crates = [
       {
         name = "proxmox-auth-api";
@@ -159,7 +159,7 @@
     name = "librust-proxmox-base64-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "a5015e9684f62f7dc4f28111dec8971dd33a40d4";
-
+    
     sha256 = "0c3f1dcsh5zz9gq91a1772zxg16vfxpvjnpj0xzkkhl4k57dbryr";
     crates = [
       {
@@ -172,7 +172,7 @@
     name = "librust-proxmox-borrow-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "82beb937ad4308848cb50ab619320d3b553060f9";
-
+    
     sha256 = "1929f28nc5w0asigvrm44wa5i93wmkhyf4zbj754k5xzr14qg8cg";
     crates = [
       {
@@ -185,7 +185,7 @@
     name = "librust-proxmox-client-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "2b21ed67474ac26b57964354445b2b39bdbf4157";
-
+    
     sha256 = "0ajm4mdxq35rx13vadm3mq6l935nkyvnl5iq6gy4kykr1j718phq";
     crates = [
       {
@@ -197,9 +197,9 @@
   {
     name = "librust-proxmox-compression-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "47719bb5836d23cfebd7904e95e5bf6770d6db4f";
-
-    sha256 = "1ryd3h7nxa7gia9z52ia985gia1dyvhclsjdh4adiyrikbgzccsz";
+    rev = "07aad061ee24502b2bdb4695c1e594b00818d90f";
+    
+    sha256 = "04cbc75bcib1imknw0cmva9awz73nay3mx73vd8msni5q6xdkrn4";
     crates = [
       {
         name = "proxmox-compression";
@@ -210,9 +210,9 @@
   {
     name = "librust-proxmox-config-digest-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "04fa1610da66aa4a3782a28f7d79c1043d4b42ed";
-
-    sha256 = "0nxpm806civ5qx33h1r8qdi6hcxr656pr52d6c3n5ymgknx1h3aj";
+    rev = "6d1bdcbb38fb0358495f404e8cad38231498f1bf";
+    
+    sha256 = "05q2vff5z7ms8vv14l1z690gncmapjc5wxffzsq4vfd2cpbg4ig6";
     crates = [
       {
         name = "proxmox-config-digest";
@@ -224,7 +224,7 @@
     name = "librust-proxmox-daemon-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "de88fc9a481042a1d10164687515f5496c13a762";
-
+    
     sha256 = "1m0rkarpmk2yxl2xkc04adxj4fnz39s09kcqgbd081jh6sv90vq3";
     crates = [
       {
@@ -236,9 +236,9 @@
   {
     name = "librust-proxmox-dns-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "4ea106bee233a996afbc1ce2dff6179f4f13433a";
-
-    sha256 = "08srksgqpx1lqx99npk40imd9s70bms4p3k445h8byxr6znb5rxn";
+    rev = "ad022fe03631d74be151e91ececb9698c55465a8";
+    
+    sha256 = "0bdwrkadk26vb9c14qrmkkcil5ddq8vyhb3wpm1isxax0fwkhbh2";
     crates = [
       {
         name = "proxmox-dns-api";
@@ -249,9 +249,9 @@
   {
     name = "librust-proxmox-frr-dev";
     url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
-    rev = "05b8fc9e7d004e821c7907dc4897b475cf97ac66";
-
-    sha256 = "1y46wpxdkk964h8magz3h4k51z8hqqydnb68316jaamk1jflj9cl";
+    rev = "e36668c887ffd349ca52553254476d1c52a5388b";
+    
+    sha256 = "0nv3nfd2rzw060w3xvlyq035kizj2pmprwk5kx4a9whq3qfaq1s3";
     crates = [
       {
         name = "proxmox-frr";
@@ -262,9 +262,9 @@
   {
     name = "librust-proxmox-http-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "e43876114c5ea1cdbd13456682d91b8a7be02d2b";
-
-    sha256 = "1ms8q65ynj1daqcqv98ylck1a5ski431mlbm1iyns6s9yf1f8mkh";
+    rev = "118bcd6ffa8df3fd17c7a9e4c677e6dd5f3949a9";
+    
+    sha256 = "15mpq3x3q20f51ya25bdnh1r2nqhaj3vas2r4ab34jbbxk13x1bb";
     crates = [
       {
         name = "proxmox-http";
@@ -276,7 +276,7 @@
     name = "librust-proxmox-http-error-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "c54d689db2328803d1c7944311e55bc83805a1fa";
-
+    
     sha256 = "1q39jkgjbn4cd7crvdinpx3z60zz53xyk0rfv10vkp0h46xd8da8";
     crates = [
       {
@@ -288,9 +288,9 @@
   {
     name = "librust-proxmox-human-byte-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "000432028d39633918cc9ae9ced55b5dc5141564";
-
-    sha256 = "0wsc0srrfkaljbb7gb8k0d2p1shrg5zpx415545y2sfc40a50fvm";
+    rev = "07e146b60c147bdfc7a4a1f07f044808078fc4a0";
+    
+    sha256 = "0dd09x76fffdijgqp4pcdy9s5hvir2xfkz30hgxh6wz56dj0pxlq";
     crates = [
       {
         name = "proxmox-human-byte";
@@ -301,9 +301,9 @@
   {
     name = "librust-proxmox-io-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "b04e04b13d835b64abd30e1baf5974023cfcc370";
-
-    sha256 = "1dqi3aqp91ks5np9k4m70s05x57p7jnx63hlsy7871vs7yqvf7f3";
+    rev = "bb3016b84666f707899c36b679c145902510ea1f";
+    
+    sha256 = "1wyn07lbbjxhxv9367gg784jr881jmsdnz1rig9abfhj2p2dn28i";
     crates = [
       {
         name = "proxmox-io";
@@ -315,7 +315,7 @@
     name = "librust-proxmox-lang-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "11076aa817184c94536483fc16e0f653a68b5cf0";
-
+    
     sha256 = "1xml4z38zf03p8md8g0zysyn92klpl93dpafsry4lwmnlripv19b";
     crates = [
       {
@@ -327,9 +327,9 @@
   {
     name = "librust-proxmox-ldap-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3ccba3065a9165ae949eabbd5a3ae08cf018cef7";
-
-    sha256 = "0gz43z36j89mkidsri0hw75y9l244pcf5lbamq44s6d8gdsniz4m";
+    rev = "c13754571eb37e157fa5dc9d21651dc29827459d";
+    
+    sha256 = "03cv9sgxcxmrlk4h4mb072aq4ds44pds07hlh72lrbrp4kjaa7nh";
     crates = [
       {
         name = "proxmox-ldap";
@@ -341,7 +341,7 @@
     name = "librust-proxmox-log-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "4a70ad566609a893451220b2ba0d4451a893e93e";
-
+    
     sha256 = "17sqf08w4qr3i0zpi5psfwlyv7vaxwj7kfa9ibfs0i1sqpzk3cvb";
     crates = [
       {
@@ -353,9 +353,9 @@
   {
     name = "librust-proxmox-login-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "d22a98772c2cea7c49d469255ae1ed2060a10e7d";
-
-    sha256 = "1h8w4xbappq9cvjcgnmfra4snfs2l6323y5bzr7cvz4xi4wfx269";
+    rev = "4eb5517830ae58ca522bfe9f90abac1753579889";
+    
+    sha256 = "1y44rivch5zci1501nazyldy7qkf1n547245y2yy6ikah7s04x9j";
     crates = [
       {
         name = "proxmox-login";
@@ -367,7 +367,7 @@
     name = "librust-proxmox-metrics-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "c6830856f5558b5a812f47d659e817a5543c7976";
-
+    
     sha256 = "0790rzjf12i07i7kiphc3llzj206hbq9argjp6bl1019hxf28ywh";
     crates = [
       {
@@ -379,9 +379,9 @@
   {
     name = "librust-proxmox-network-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "16588a7d07deedfe84433837ca90743e23c8ad3b";
-
-    sha256 = "13rdix51vmsc31xhmgkjyy5x1jy5anr46p8kk779dcn6j01453b3";
+    rev = "55ecc70c85986dd7d692a42284a96f977ff732b6";
+    
+    sha256 = "10j35q04ma464glxlmh7pvlnk1ysnk71kvda4k9a5hvd4sfmns36";
     crates = [
       {
         name = "proxmox-network-api";
@@ -392,9 +392,9 @@
   {
     name = "librust-proxmox-network-types-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "ffe61b2cc31de6592be8129aadba5918dd9d4911";
-
-    sha256 = "1gv3krnvdpjwl4gfgvdjvhrpxcdc5dwzdrvrjk3by0mmvlc9dp3f";
+    rev = "b2e044225ba078a892e80405f424f25f9518417b";
+    
+    sha256 = "1mm6lfnrji5gxlsa591gswcjdn5wh3g48f84d7n6lh42g5ibb3ks";
     crates = [
       {
         name = "proxmox-network-types";
@@ -403,24 +403,11 @@
     ];
   }
   {
-    name = "librust-proxmox-node-status-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "fe863e169e9c1a775a4065dd007ab9ceed4ce07b";
-
-    sha256 = "1w24pmiqhxqbkafc2kwra0vnzrhjhrf1fw1b6vyqhljzhl3s16jy";
-    crates = [
-      {
-        name = "proxmox-node-status";
-        path = "proxmox-node-status";
-      }
-    ];
-  }
-  {
     name = "librust-proxmox-notify-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "43e3a6ca48e1352e2c20cf8616915a31a9ad8c10";
-
-    sha256 = "0rn1jaymr50vgqpbbg604kgq03wqg7zjclx6g9ab5y7jb59av9i7";
+    rev = "52b04982627911d4d7255bd25c78d7eb4d695bcf";
+    
+    sha256 = "1xaamw59agm1dcphz2hpl46x8xpavl8vjjnjzrkqzm67vh3zrshp";
     crates = [
       {
         name = "proxmox-notify";
@@ -429,10 +416,23 @@
     ];
   }
   {
+    name = "librust-proxmox-oci-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "0ae01a3d97941a8919fd728a211fb5814a6cec56";
+    
+    sha256 = "07fa33hikkf920rkdpk9vn0f3y9dgxf06chq0083zpz6zngjp9xp";
+    crates = [
+      {
+        name = "proxmox-oci";
+        path = "proxmox-oci";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-openid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "cddc6b525b92cea57694297fba678d49e348ba8a";
-
+    
     sha256 = "1wkrs2xid9wfzv4i9r0kpcdrxhr8rhlp5hwyzbjvm2vi50h0d0jl";
     crates = [
       {
@@ -445,7 +445,7 @@
     name = "librust-proxmox-product-config-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "d42d5038bc4998200d18c9d190b9b013d6522722";
-
+    
     sha256 = "1dsjziab9d8lm34fdd4fh2rjm6xz3fas6rwaya0gzc8dwmvn4ar2";
     crates = [
       {
@@ -457,9 +457,9 @@
   {
     name = "librust-proxmox-resource-scheduling-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "5625354accdede10680287257d959e135b6742d0";
-
-    sha256 = "02bh82r3yccvgydvpi23k8nh0r2wn3503ji0z35fl5npb7ayzvsk";
+    rev = "69d1fddb642a2a102095cfa10e41ef10abc8a5e6";
+    
+    sha256 = "1ag2j6rb89321wps1isxjnyj8hr45hxrgx1jh84k19kj8322vrfb";
     crates = [
       {
         name = "proxmox-resource-scheduling";
@@ -470,9 +470,9 @@
   {
     name = "librust-proxmox-rest-server-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "03a7d59ac477f804c7acfbc1d4f4f8351715b852";
-
-    sha256 = "1zhccvksqywdnqrjgjyhrbhrbbm13sv1yhkp6k3cxa1a0273a0sc";
+    rev = "391df828cfe5d0918913ebbb172b11a3d9598d14";
+    
+    sha256 = "0rc55hxjgi1l4g28lgp02v0f49knfajr1b9w931xv71nj0yxa82n";
     crates = [
       {
         name = "proxmox-rest-server";
@@ -483,9 +483,9 @@
   {
     name = "librust-proxmox-router-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "35c28da99fc02a8f9de3e010ccac3dc8167e8c31";
-
-    sha256 = "1a51xxz9l5gs02dyxhx1zcc1733j543n04xnx5557cxbyfcj5d9h";
+    rev = "cd920ed03ba6fa8210d4366e64742c89aa60ed64";
+    
+    sha256 = "06bvp82n6f5a8r58f9r51v9zilcv2489r1mi90ksxfng10v0pr12";
     crates = [
       {
         name = "proxmox-router";
@@ -497,7 +497,7 @@
     name = "librust-proxmox-s3-client-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "de54ac7f42817a66a9724e393d470a5730de5e72";
-
+    
     sha256 = "0q6lambyhfbkr4yv61v1j4l5x61bb3lia2mh2rgc4l9fksnaxgg2";
     crates = [
       {
@@ -509,9 +509,9 @@
   {
     name = "librust-proxmox-schema-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "c404bcbe16f5b9bab5ddea06d2b1274fae0667c3";
-
-    sha256 = "0h4c8i9aya8m429vadafjhvghv2lvphiwy4fypyd55lw02hi4cnb";
+    rev = "ed34cf12938cf9f78162ba5a2d98956b416a8883";
+    
+    sha256 = "0qk5jzlp8ks9gpaya88hs1v7slrhswxbwd023kkc8wg92bb1g7ir";
     crates = [
       {
         name = "proxmox-schema";
@@ -522,9 +522,9 @@
   {
     name = "librust-proxmox-sdn-types-dev";
     url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
-    rev = "f662e9221b1705c1660ef14257c7c54fd10101ab";
-
-    sha256 = "0v2mffg4wcjyppxanyxzvgsc4l90milivni4x31c8lhsb0k5gddc";
+    rev = "17af874c77f767323a0cf19ef1345f9910ccb5ff";
+    
+    sha256 = "187g9sy767qh8hzmj3ydcys5b3i2di2dnbvrpkzm0h0g3xskk2q0";
     crates = [
       {
         name = "proxmox-sdn-types";
@@ -535,9 +535,9 @@
   {
     name = "librust-proxmox-section-config-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "61b5788a639e3e74f85666f8c240d6b37acdf9fa";
-
-    sha256 = "0w8zggdf9dcfbk8f11ipq50z0id9fab0jadsrjn8vw1w5gh5rwf9";
+    rev = "2a375fa97ea361fb7b2c283b754478a1a6e791c7";
+    
+    sha256 = "1f3rlcf8w0zfdn3znah79k3f55rqjvrg2k0w02klsr7knqv8s050";
     crates = [
       {
         name = "proxmox-section-config";
@@ -548,9 +548,9 @@
   {
     name = "librust-proxmox-sendmail-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "f03e6651032acce45246f49a6bc6bc1f0794244b";
-
-    sha256 = "098px04lajing8pypax7lqardafdzsm9ikpg8qdcwx7p1qhsnjvy";
+    rev = "13340ae4452f8e07d2b35769233914ab8cb84192";
+    
+    sha256 = "1yafbqafwv7bjgc414p6vm6hiy0fwb53sh9wsp2l3m83i5ixx464";
     crates = [
       {
         name = "proxmox-sendmail";
@@ -561,9 +561,9 @@
   {
     name = "librust-proxmox-serde-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "521ebf5bf0160f7a8843d363073ebb9e21d101c1";
-
-    sha256 = "0mwsdg7j6xa1nlvgnqqlpw49vazs399f2m3c4g5p08hx39wvlhzv";
+    rev = "84ee8f4e5d825625a3d957b341f5c55cca1e4b32";
+    
+    sha256 = "06ygg8j5h466k0hvbbf0323abjcv7j72qxn2vkvfxxb7dygagwsd";
     crates = [
       {
         name = "proxmox-serde";
@@ -575,7 +575,7 @@
     name = "librust-proxmox-shared-cache-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "d23c49fe82b9bd7a15c7c58585be443116f3045a";
-
+    
     sha256 = "151czqr9v08vqp2jfgdbc79fbq5v7jpyhifzn244zrvmklpgsmiv";
     crates = [
       {
@@ -588,7 +588,7 @@
     name = "librust-proxmox-shared-memory-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "eb1116c1e3fd27e391a9dde487eabc673368a6c5";
-
+    
     sha256 = "0gccrgy2qlggqwhb42zkypn8bdg05xxd62g4gaz9mzc1wby9bk34";
     crates = [
       {
@@ -600,9 +600,9 @@
   {
     name = "librust-proxmox-simple-config-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "c273e86e0cef266e11ccfe2d2522e79173ffdaff";
-
-    sha256 = "1zma7rj7ksl0n5msnwbi195kkxchj3ax9h5fg3q8v5v70dmv8vv9";
+    rev = "35587a12af4197fb8243c9239a27302d2fc283b8";
+    
+    sha256 = "1f81702jxdi9mxbrix4fsq71aw5nmj41myi6y45cimx1lm49gpdg";
     crates = [
       {
         name = "proxmox-simple-config";
@@ -614,7 +614,7 @@
     name = "librust-proxmox-sortable-macro-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "a1766995b589c5668a7f9d4f0b15e6fbe32b6a36";
-
+    
     sha256 = "1p1q732ni8cmx3hckac01q93y1bq2qrpr0zgigwq095gg6xik680";
     crates = [
       {
@@ -626,9 +626,9 @@
   {
     name = "librust-proxmox-subscription-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "5f641e5a99e89d52ccdde500d79ce2c0d6dea71a";
-
-    sha256 = "1s249m4z776czzbhi0s4a8vshh2p7pw305iqxfsjnk06ii6zghnf";
+    rev = "7c2a07e69b42b73e149489027409932af623ef94";
+    
+    sha256 = "1mkm2wvpr7nn03b9f2kxlylwi2sf8nyynk3kjy10aam8x1kdnxa7";
     crates = [
       {
         name = "proxmox-subscription";
@@ -640,7 +640,7 @@
     name = "librust-proxmox-sys-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "4919e03d9bd2b6b0be914667eedcff81e727ab12";
-
+    
     sha256 = "1990ywrlzd9jiliskcha96kmqbdlw6bcwixyjsdnm8kpnc8rrxzk";
     crates = [
       {
@@ -652,9 +652,9 @@
   {
     name = "librust-proxmox-syslog-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "b79913168ac606619b4934a614dcfc83cc6833ee";
-
-    sha256 = "1q3z4csi2l2m1bppk9rv7hmf9mlwsvfa7a7c3iil0c9ws3767x0d";
+    rev = "7440ea15b3a70fe4b00a4986957dfd031053ac14";
+    
+    sha256 = "08ysn6z0cfcic9w0xcpm9a590ry4dd60n3gs2c9nj5n81gz06rr8";
     crates = [
       {
         name = "proxmox-syslog-api";
@@ -666,7 +666,7 @@
     name = "librust-proxmox-systemd-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "fb3e8ca768c5c815fc55ca78e095df35a1c06d78";
-
+    
     sha256 = "1lblv6sw4rrwf1xha3hz727mwas90zqykx9nwrw60s0sabw5pyic";
     crates = [
       {
@@ -678,9 +678,9 @@
   {
     name = "librust-proxmox-tfa-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "7de539b26cbca1bdc2a24f3591e59469d95746e1";
-
-    sha256 = "0x4nvz5ysxh0s0dgf86salac086b25apsllgqisb379670wfn9gn";
+    rev = "320f2f0c600b03829bfe534ea4bed4730122dad0";
+    
+    sha256 = "01dnv4jcagpv8vkajm98l1bml3z8w5sj2p214y94l4915j7991xm";
     crates = [
       {
         name = "proxmox-tfa";
@@ -691,9 +691,9 @@
   {
     name = "librust-proxmox-time-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3d8d38799e403e069679aa942565d95bc65b48fe";
-
-    sha256 = "0ga8zp7kqvlzvjal9zgwi4qx7nj0grjg0a9xb9ll6anx08si0jac";
+    rev = "3db314886689109607ff9756fff04c4710e2c410";
+    
+    sha256 = "072f7b3pabkkhf7v349n2ns99xhqlamzs7wvhipgbz354rv62q42";
     crates = [
       {
         name = "proxmox-time-api";
@@ -705,7 +705,7 @@
     name = "librust-proxmox-time-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "a79ccc19071ad69ee419a58f38577216182ffbaa";
-
+    
     sha256 = "1kl0syqwf59654i43hm4ca0l124wixl43mlvhhj9p2j81iydyyzn";
     crates = [
       {
@@ -718,8 +718,8 @@
     name = "librust-proxmox-uuid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "391412712c4dd6f86157eb0c3767ef6e36750896";
-
-    sha256 = "sha256-c3Z7LveHM34DNlEcVpFFgP8sQFIDYjPsxO6wdK2RdgE=";
+    
+    sha256 = "00bnj6np9c7fqkn36qh3a902rzw08n8mc72i6q1pwcw7ywp7nxkk";
     crates = [
       {
         name = "proxmox-uuid";
@@ -730,9 +730,9 @@
   {
     name = "librust-proxmox-ve-config-dev";
     url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
-    rev = "587c67fdb139463a5e6218dd17d1cd442babe9b5";
-
-    sha256 = "1xdnkcya5xi09gddf5y197bz9mvyxz6crdrq4xhwqavc3p6bvwv1";
+    rev = "4f236d3ce6aa882158bfc01a5cf86d87632542df";
+    
+    sha256 = "1py4rr61rrpmavphhibc7nq6764kiy4q9cns0s38sjgrfd9fphfw";
     crates = [
       {
         name = "proxmox-ve-config";
@@ -744,7 +744,7 @@
     name = "librust-proxmox-worker-task-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "b7292443a12b2f0c43b5d4e9bee6334e0e6241ff";
-
+    
     sha256 = "1q0pvx1vrhpva2n7ykvpzgch735c7vhg5lvb4n6946l33dn0cyna";
     crates = [
       {
@@ -754,11 +754,24 @@
     ];
   }
   {
+    name = "librust-proxmox-node-status-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "fe863e169e9c1a775a4065dd007ab9ceed4ce07b";
+    
+    sha256 = "1w24pmiqhxqbkafc2kwra0vnzrhjhrf1fw1b6vyqhljzhl3s16jy";
+    crates = [
+      {
+        name = "proxmox-node-status";
+        path = "proxmox-node-status";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-yew-comp-dev";
     url = "git://git.proxmox.com/git/ui/proxmox-yew-comp.git";
-    rev = "30676b69220b07351d6eef19c48f7822ee5af32c";
-
-    sha256 = "1m2rjhycgakq6887r1s6nn80dz264qfpcqr5fdr8ipymwwqbqikd";
+    rev = "3bac5554b10db80952eac259de034ebe46138808";
+    
+    sha256 = "1g1dsjdfbhzp8qiwiba7xqbxmp823gka7mc9yipzb6cqwi3qw95r";
     crates = [
       {
         name = "proxmox-yew-comp";
@@ -767,11 +780,24 @@
     ];
   }
   {
+    name = "librust-pve-api-types-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "54299e63614cc570ff871af88091bb907225fd25";
+    
+    sha256 = "1fkhahp92p8nr1x25aqcwyhb3v4a8x08sr0vwh7sgkpxr9s7h3yz";
+    crates = [
+      {
+        name = "pve-api-types";
+        path = "pve-api-types";
+      }
+    ];
+  }
+  {
     name = "librust-pwt-dev";
     url = "git://git.proxmox.com/git/ui/proxmox-yew-widget-toolkit.git";
-    rev = "41d70cb7d845ca8f50634386c13972c973248fcb";
-
-    sha256 = "025jxzj5q6mf6lqv22dya4lb48a1j3kik8jigsn4y3jf7l5x8x5q";
+    rev = "10b2149f4372bf38a2268f89c12302228ccd1031";
+    
+    sha256 = "0423zhlvcngfzakzac42zvg54a338rkps0f6379qisalimf0y8ik";
     crates = [
       {
         name = "pwt";
@@ -782,9 +808,9 @@
   {
     name = "librust-pwt-macros-dev";
     url = "git://git.proxmox.com/git/ui/proxmox-yew-widget-toolkit.git";
-    rev = "41d70cb7d845ca8f50634386c13972c973248fcb";
-
-    sha256 = "025jxzj5q6mf6lqv22dya4lb48a1j3kik8jigsn4y3jf7l5x8x5q";
+    rev = "23d4a1627b2cd89e97cba561a0824a2891b41452";
+    
+    sha256 = "0zjzh1iclb6gcidn5csxbbgdsz84s9mdgr4bv636ppchfa5j2vjv";
     crates = [
       {
         name = "pwt-macros";
@@ -793,23 +819,10 @@
     ];
   }
   {
-    name = "librust-pve-api-types-dev";
-    url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "54299e63614cc570ff871af88091bb907225fd25";
-
-    sha256 = "1fkhahp92p8nr1x25aqcwyhb3v4a8x08sr0vwh7sgkpxr9s7h3yz";
-    crates = [
-      {
-        name = "pve-api-types";
-        path = "pve-api-types";
-      }
-    ];
-  }
-  {
     name = "librust-pxar-dev";
     url = "git://git.proxmox.com/git/pxar.git";
     rev = "993c66fcb8819770f279cb9fb4d13f58f367606c";
-
+    
     sha256 = "1bqfdq15kq45wrqmsh559ijbv48k73fjca5l4198mflgii6f942p";
     crates = [
       {

--- a/pkgs/pve-yew-mobile-gui/sources.nix
+++ b/pkgs/pve-yew-mobile-gui/sources.nix
@@ -717,9 +717,9 @@
   {
     name = "librust-proxmox-uuid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "aced6d2b7d8c47e1a5825d825ac988eac7d90c8a";
+    rev = "391412712c4dd6f86157eb0c3767ef6e36750896";
 
-    sha256 = "01famhymykh5l99iq5gg6rifbfn8gwxpi4zlpnihbiv83kqx6xvc";
+    sha256 = "sha256-c3Z7LveHM34DNlEcVpFFgP8sQFIDYjPsxO6wdK2RdgE=";
     crates = [
       {
         name = "proxmox-uuid";

--- a/pkgs/qrcodejs/default.nix
+++ b/pkgs/qrcodejs/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  uglify-js,
+  pve-update-script,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qrcodejs";
+  version = "1.20230525-pve1";
+
+  src = fetchgit {
+    url = "git://git.proxmox.com/git/libjs-qrcodejs.git";
+    rev = "4a28dec7f15ac06e0505a4c2c4fb899a1f45845e";
+    hash = "sha256-XRsAQRCT9guaYBXzluBQqdmL7EARMdVR8nw8BhhBSQk=";
+  };
+
+  nativeBuildInputs = [ uglify-js ];
+
+  sourceRoot = "${src.name}/src";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/javascript/qrcodejs
+    cp qrcode.min.js $out/share/javascript/qrcodejs/
+    runHook postInstall
+  '';
+
+  passthru.updateScript = pve-update-script { };
+
+  meta = with lib; {
+    description = "QRCode.js - Cross-browser QRCode generator for JavaScript";
+    homepage = "https://git.proxmox.com/?p=libjs-qrcodejs.git";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      camillemndn
+      julienmalka
+    ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/termproxy/Cargo.lock
+++ b/pkgs/termproxy/Cargo.lock
@@ -56,21 +56,21 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -113,14 +113,14 @@ dependencies = [
 
 [[package]]
 name = "proxmox-io"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "endian_trait",
 ]
 
 [[package]]
 name = "proxmox-termproxy"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "form_urlencoded",
@@ -184,7 +184,7 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "pbs-api-types"
-version = "1.0.0"
+version = "1.0.4"
 
 [[patch.unused]]
 name = "perlmod"
@@ -196,27 +196,27 @@ version = "0.10.0"
 
 [[patch.unused]]
 name = "proxmox-access-control"
-version = "1.0.0"
+version = "1.2.0"
 
 [[patch.unused]]
 name = "proxmox-acme"
-version = "1.0.0"
+version = "1.0.3"
 
 [[patch.unused]]
 name = "proxmox-acme-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-api-macro"
-version = "1.4.0"
+version = "1.4.3"
 
 [[patch.unused]]
 name = "proxmox-apt"
-version = "0.99.0"
+version = "0.99.5"
 
 [[patch.unused]]
 name = "proxmox-apt-api-types"
-version = "2.0.0"
+version = "2.0.2"
 
 [[patch.unused]]
 name = "proxmox-async"
@@ -224,7 +224,7 @@ version = "0.5.0"
 
 [[patch.unused]]
 name = "proxmox-auth-api"
-version = "1.0.0"
+version = "1.0.4"
 
 [[patch.unused]]
 name = "proxmox-base64"
@@ -240,11 +240,11 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-compression"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-config-digest"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-daemon"
@@ -252,11 +252,15 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-dns-api"
-version = "1.0.0"
+version = "1.0.1"
+
+[[patch.unused]]
+name = "proxmox-frr"
+version = "0.2.0"
 
 [[patch.unused]]
 name = "proxmox-http"
-version = "1.0.0"
+version = "1.0.4"
 
 [[patch.unused]]
 name = "proxmox-http-error"
@@ -264,7 +268,7 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-human-byte"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-lang"
@@ -272,11 +276,15 @@ version = "1.5.0"
 
 [[patch.unused]]
 name = "proxmox-ldap"
-version = "1.0.0"
+version = "1.1.0"
 
 [[patch.unused]]
 name = "proxmox-log"
 version = "1.0.0"
+
+[[patch.unused]]
+name = "proxmox-login"
+version = "1.0.3"
 
 [[patch.unused]]
 name = "proxmox-metrics"
@@ -284,15 +292,23 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-network-api"
-version = "1.0.0"
+version = "1.0.4"
+
+[[patch.unused]]
+name = "proxmox-network-types"
+version = "0.1.2"
 
 [[patch.unused]]
 name = "proxmox-notify"
-version = "1.0.0"
+version = "1.0.3"
+
+[[patch.unused]]
+name = "proxmox-oci"
+version = "0.2.0"
 
 [[patch.unused]]
 name = "proxmox-openid"
-version = "1.0.0"
+version = "1.0.2"
 
 [[patch.unused]]
 name = "proxmox-product-config"
@@ -304,27 +320,35 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-rest-server"
-version = "1.0.0"
+version = "1.0.2"
 
 [[patch.unused]]
 name = "proxmox-router"
-version = "3.2.2"
+version = "3.2.3"
+
+[[patch.unused]]
+name = "proxmox-s3-client"
+version = "1.2.3"
 
 [[patch.unused]]
 name = "proxmox-schema"
-version = "4.1.0"
+version = "5.0.1"
+
+[[patch.unused]]
+name = "proxmox-sdn-types"
+version = "0.1.1"
 
 [[patch.unused]]
 name = "proxmox-section-config"
-version = "3.1.0"
+version = "3.1.1"
 
 [[patch.unused]]
 name = "proxmox-sendmail"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-serde"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-shared-cache"
@@ -336,7 +360,7 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-simple-config"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-sortable-macro"
@@ -344,7 +368,7 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-subscription"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-sys"
@@ -352,7 +376,7 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-syslog-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-systemd"
@@ -360,7 +384,7 @@ version = "1.0.0"
 
 [[patch.unused]]
 name = "proxmox-tfa"
-version = "6.0.0"
+version = "6.0.4"
 
 [[patch.unused]]
 name = "proxmox-time"
@@ -368,7 +392,7 @@ version = "2.1.0"
 
 [[patch.unused]]
 name = "proxmox-time-api"
-version = "1.0.0"
+version = "1.0.1"
 
 [[patch.unused]]
 name = "proxmox-uuid"
@@ -376,11 +400,27 @@ version = "1.1.0"
 
 [[patch.unused]]
 name = "proxmox-ve-config"
-version = "0.3.0"
+version = "0.4.5"
 
 [[patch.unused]]
 name = "proxmox-worker-task"
 version = "1.0.0"
+
+[[patch.unused]]
+name = "proxmox-yew-comp"
+version = "0.7.0"
+
+[[patch.unused]]
+name = "pve-api-types"
+version = "8.1.0"
+
+[[patch.unused]]
+name = "pwt"
+version = "0.7.6"
+
+[[patch.unused]]
+name = "pwt-macros"
+version = "0.5.0"
 
 [[patch.unused]]
 name = "pxar"

--- a/pkgs/termproxy/default.nix
+++ b/pkgs/termproxy/default.nix
@@ -13,12 +13,12 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "termproxy";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/pve-xtermjs.git";
-    rev = "c69379f49db91429eb01ea56b47f2a2832fec8e7";
-    hash = "sha256-U4sT3fXsq/Tza00ycnPaEaQrYlBtscsv5rRCJZPM3Uw=";
+    rev = "1c92330cccb21fb65abcff6e35848b712592dccb";
+    hash = "sha256-it1zIt+vVSgGw8mII+l7cq+vyV7tnuqNkBbgbBw7szw=";
   };
 
   cargoLock = {

--- a/pkgs/termproxy/sources.nix
+++ b/pkgs/termproxy/sources.nix
@@ -639,9 +639,9 @@
   {
     name = "librust-proxmox-uuid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "aced6d2b7d8c47e1a5825d825ac988eac7d90c8a";
+    rev = "391412712c4dd6f86157eb0c3767ef6e36750896";
 
-    sha256 = "01famhymykh5l99iq5gg6rifbfn8gwxpi4zlpnihbiv83kqx6xvc";
+    sha256 = "sha256-c3Z7LveHM34DNlEcVpFFgP8sQFIDYjPsxO6wdK2RdgE=";
     crates = [
       {
         name = "proxmox-uuid";

--- a/pkgs/termproxy/sources.nix
+++ b/pkgs/termproxy/sources.nix
@@ -3,7 +3,7 @@
     name = "librust-pathpatterns-dev";
     url = "git://git.proxmox.com/git/pathpatterns.git";
     rev = "42e5e96e30297da878a4d4b3a7fa52b65c1be0ab";
-
+    
     sha256 = "0fq2ik07wwd291m1r7z37zajfml15gb1h3gm88my12pn1x723hak";
     crates = [
       {
@@ -15,9 +15,9 @@
   {
     name = "librust-pbs-api-types-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "956cd368bb7c80740bcc6f2f50fa70de26e6d788";
-
-    sha256 = "0mims8ij7y7gywvipz6159x3if6ybp4ghacrxaly2knk3g5d8c49";
+    rev = "7b903765b50a281e97f434c750eef036abc2b856";
+    
+    sha256 = "0wxxdhfsrrn91i8ngxaa9r976kxai86a0669pg3cafacbaikf7z7";
     crates = [
       {
         name = "pbs-api-types";
@@ -29,7 +29,7 @@
     name = "librust-perlmod-dev";
     url = "git://git.proxmox.com/git/perlmod.git";
     rev = "3f0fcc1f1601bad6ccacd38796865a927d100cda";
-
+    
     sha256 = "1q6zq05dq5awfy50mi6cj374g0lnvy1vi4x4w6sw2c7xphswrr5n";
     crates = [
       {
@@ -42,7 +42,7 @@
     name = "librust-perlmod-macro-dev";
     url = "git://git.proxmox.com/git/perlmod.git";
     rev = "4f946ea4362a5bdbbb131aa71dc6e3b19cb02467";
-
+    
     sha256 = "0rnyd6jhkxacclm342239cvz903fwxgnmy07lwvszyiy0f23im0z";
     crates = [
       {
@@ -54,9 +54,9 @@
   {
     name = "librust-proxmox-access-control-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "160506ea3884d5c38fee29d11dd03a352348d6ad";
-
-    sha256 = "1yl3xhwd8klzrzyr9nbll9sa3b8c4nnbhxcndghqbria5lqjibv1";
+    rev = "ea795fad2924131a323408ac8cdc62126d9e4d8d";
+    
+    sha256 = "0762si4sxby6s0z7csfz3386pybddm22zgs7sh11i4553j56rpjm";
     crates = [
       {
         name = "proxmox-access-control";
@@ -67,9 +67,9 @@
   {
     name = "librust-proxmox-acme-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "beaadf89ea2b0de080ea99c52cbef04753498a06";
-
-    sha256 = "01v9w2xcc1dijsdgngcngicjjrbm5irc9z011ap8mw37rkfdq7iz";
+    rev = "2383831533bf316ce0dea93205cd263c101452e9";
+    
+    sha256 = "00r7wmcl7fk900939cjc2dmnj2bbv8wjp19gdr500dali1v7mxk9";
     crates = [
       {
         name = "proxmox-acme-api";
@@ -80,9 +80,9 @@
   {
     name = "librust-proxmox-acme-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "6b4de64dc5618611e2616e3357fbf386de7a02f0";
-
-    sha256 = "1qfc8f6gij17z6k0wc5vaarrycfsjkhxrwz3ay6skfmnj1z635ck";
+    rev = "039d25dfcfb53b60c641b46fd471c45acc2811e0";
+    
+    sha256 = "00c3mjd223r6x0a8jzdz3j6qrrdixq8r5qyngn4nds1rg0k9vhxw";
     crates = [
       {
         name = "proxmox-acme";
@@ -93,9 +93,9 @@
   {
     name = "librust-proxmox-api-macro-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3f59c3f3815bccc8485b7e76051ef5cc61cb363a";
-
-    sha256 = "1hl4b1zqrj0kjgzpkqkk0y0y58j2zrr8c8v0xbrpl4lw64d0jdl1";
+    rev = "582bbf07f097db2984ed95e680cab0674a476acb";
+    
+    sha256 = "0ddgk6iv6vzpf2wh4qzqbk3vf3dagqczhv0mr2wvgc5i1k0acsqr";
     crates = [
       {
         name = "proxmox-api-macro";
@@ -106,9 +106,9 @@
   {
     name = "librust-proxmox-apt-api-types-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "e2305b8f8e610e713b5acb9d90f42a1423abf1d8";
-
-    sha256 = "09ywa6fkk7x10sa3234p3zkbjvsj404a0pqwbq59f1pkn5sd3b59";
+    rev = "88183452e3b6d86bd8f9e03d222d5c8d1d8a0058";
+    
+    sha256 = "1yqhxkjv69w2fdmm27z7ywffnvy1z1mkq49qc36fj0ivgccv2af3";
     crates = [
       {
         name = "proxmox-apt-api-types";
@@ -119,9 +119,9 @@
   {
     name = "librust-proxmox-apt-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "80f76ec62fde055f522f0a356353ec491d9854ce";
-
-    sha256 = "0izwnap5slyrkdisrczd6g5knajmd45cjin54n93c12jfqdzka8y";
+    rev = "6bcbf092768887f7d5d7036b76723f5bd20aec7f";
+    
+    sha256 = "0r4mi2vlg3wlbv9539v42rikn92d9zndmskkk0m7ad5xid7c4nz9";
     crates = [
       {
         name = "proxmox-apt";
@@ -133,7 +133,7 @@
     name = "librust-proxmox-async-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "9820e1ca7694c505b3cb9711f124026e0bb7ea4a";
-
+    
     sha256 = "0inf0iqs8hhz4xanvin0131f8a7ypk4yvfbl3brg6gf2rn6p6rhr";
     crates = [
       {
@@ -145,9 +145,9 @@
   {
     name = "librust-proxmox-auth-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "125cc32b777bde7e9f6691917b2de7ed8dac5dc5";
-
-    sha256 = "0v1ik5rggdif82bj7rkq6bzi1gq7755xk95ys32cja418yakbkr2";
+    rev = "8578b4912a2b32f7c063c060c2182f40c61a753f";
+    
+    sha256 = "0pk1rvb1v7gmqdjicazzr3m9lxahvbwib2vlg1mrgp93c9fpdsha";
     crates = [
       {
         name = "proxmox-auth-api";
@@ -159,7 +159,7 @@
     name = "librust-proxmox-base64-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "a5015e9684f62f7dc4f28111dec8971dd33a40d4";
-
+    
     sha256 = "0c3f1dcsh5zz9gq91a1772zxg16vfxpvjnpj0xzkkhl4k57dbryr";
     crates = [
       {
@@ -172,7 +172,7 @@
     name = "librust-proxmox-borrow-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "82beb937ad4308848cb50ab619320d3b553060f9";
-
+    
     sha256 = "1929f28nc5w0asigvrm44wa5i93wmkhyf4zbj754k5xzr14qg8cg";
     crates = [
       {
@@ -185,7 +185,7 @@
     name = "librust-proxmox-client-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "2b21ed67474ac26b57964354445b2b39bdbf4157";
-
+    
     sha256 = "0ajm4mdxq35rx13vadm3mq6l935nkyvnl5iq6gy4kykr1j718phq";
     crates = [
       {
@@ -197,9 +197,9 @@
   {
     name = "librust-proxmox-compression-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "47719bb5836d23cfebd7904e95e5bf6770d6db4f";
-
-    sha256 = "1ryd3h7nxa7gia9z52ia985gia1dyvhclsjdh4adiyrikbgzccsz";
+    rev = "07aad061ee24502b2bdb4695c1e594b00818d90f";
+    
+    sha256 = "04cbc75bcib1imknw0cmva9awz73nay3mx73vd8msni5q6xdkrn4";
     crates = [
       {
         name = "proxmox-compression";
@@ -210,9 +210,9 @@
   {
     name = "librust-proxmox-config-digest-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "04fa1610da66aa4a3782a28f7d79c1043d4b42ed";
-
-    sha256 = "0nxpm806civ5qx33h1r8qdi6hcxr656pr52d6c3n5ymgknx1h3aj";
+    rev = "6d1bdcbb38fb0358495f404e8cad38231498f1bf";
+    
+    sha256 = "05q2vff5z7ms8vv14l1z690gncmapjc5wxffzsq4vfd2cpbg4ig6";
     crates = [
       {
         name = "proxmox-config-digest";
@@ -224,7 +224,7 @@
     name = "librust-proxmox-daemon-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "de88fc9a481042a1d10164687515f5496c13a762";
-
+    
     sha256 = "1m0rkarpmk2yxl2xkc04adxj4fnz39s09kcqgbd081jh6sv90vq3";
     crates = [
       {
@@ -236,9 +236,9 @@
   {
     name = "librust-proxmox-dns-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "4ea106bee233a996afbc1ce2dff6179f4f13433a";
-
-    sha256 = "08srksgqpx1lqx99npk40imd9s70bms4p3k445h8byxr6znb5rxn";
+    rev = "ad022fe03631d74be151e91ececb9698c55465a8";
+    
+    sha256 = "0bdwrkadk26vb9c14qrmkkcil5ddq8vyhb3wpm1isxax0fwkhbh2";
     crates = [
       {
         name = "proxmox-dns-api";
@@ -247,11 +247,24 @@
     ];
   }
   {
+    name = "librust-proxmox-frr-dev";
+    url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
+    rev = "e36668c887ffd349ca52553254476d1c52a5388b";
+    
+    sha256 = "0nv3nfd2rzw060w3xvlyq035kizj2pmprwk5kx4a9whq3qfaq1s3";
+    crates = [
+      {
+        name = "proxmox-frr";
+        path = "proxmox-frr";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-http-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "fe85188161d20c638d3e96aa784beac65faaa822";
-
-    sha256 = "0ykk42my3f28i7dbda2zhw0w5df79q2db6xbvk4g10yjp4wrg7rn";
+    rev = "118bcd6ffa8df3fd17c7a9e4c677e6dd5f3949a9";
+    
+    sha256 = "15mpq3x3q20f51ya25bdnh1r2nqhaj3vas2r4ab34jbbxk13x1bb";
     crates = [
       {
         name = "proxmox-http";
@@ -263,7 +276,7 @@
     name = "librust-proxmox-http-error-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "c54d689db2328803d1c7944311e55bc83805a1fa";
-
+    
     sha256 = "1q39jkgjbn4cd7crvdinpx3z60zz53xyk0rfv10vkp0h46xd8da8";
     crates = [
       {
@@ -275,9 +288,9 @@
   {
     name = "librust-proxmox-human-byte-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "000432028d39633918cc9ae9ced55b5dc5141564";
-
-    sha256 = "0wsc0srrfkaljbb7gb8k0d2p1shrg5zpx415545y2sfc40a50fvm";
+    rev = "07e146b60c147bdfc7a4a1f07f044808078fc4a0";
+    
+    sha256 = "0dd09x76fffdijgqp4pcdy9s5hvir2xfkz30hgxh6wz56dj0pxlq";
     crates = [
       {
         name = "proxmox-human-byte";
@@ -288,9 +301,9 @@
   {
     name = "librust-proxmox-io-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "b04e04b13d835b64abd30e1baf5974023cfcc370";
-
-    sha256 = "1dqi3aqp91ks5np9k4m70s05x57p7jnx63hlsy7871vs7yqvf7f3";
+    rev = "bb3016b84666f707899c36b679c145902510ea1f";
+    
+    sha256 = "1wyn07lbbjxhxv9367gg784jr881jmsdnz1rig9abfhj2p2dn28i";
     crates = [
       {
         name = "proxmox-io";
@@ -302,7 +315,7 @@
     name = "librust-proxmox-lang-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "11076aa817184c94536483fc16e0f653a68b5cf0";
-
+    
     sha256 = "1xml4z38zf03p8md8g0zysyn92klpl93dpafsry4lwmnlripv19b";
     crates = [
       {
@@ -314,9 +327,9 @@
   {
     name = "librust-proxmox-ldap-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3ccba3065a9165ae949eabbd5a3ae08cf018cef7";
-
-    sha256 = "0gz43z36j89mkidsri0hw75y9l244pcf5lbamq44s6d8gdsniz4m";
+    rev = "c13754571eb37e157fa5dc9d21651dc29827459d";
+    
+    sha256 = "03cv9sgxcxmrlk4h4mb072aq4ds44pds07hlh72lrbrp4kjaa7nh";
     crates = [
       {
         name = "proxmox-ldap";
@@ -328,7 +341,7 @@
     name = "librust-proxmox-log-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "4a70ad566609a893451220b2ba0d4451a893e93e";
-
+    
     sha256 = "17sqf08w4qr3i0zpi5psfwlyv7vaxwj7kfa9ibfs0i1sqpzk3cvb";
     crates = [
       {
@@ -338,10 +351,23 @@
     ];
   }
   {
+    name = "librust-proxmox-login-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "4eb5517830ae58ca522bfe9f90abac1753579889";
+    
+    sha256 = "1y44rivch5zci1501nazyldy7qkf1n547245y2yy6ikah7s04x9j";
+    crates = [
+      {
+        name = "proxmox-login";
+        path = "proxmox-login";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-metrics-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "c6830856f5558b5a812f47d659e817a5543c7976";
-
+    
     sha256 = "0790rzjf12i07i7kiphc3llzj206hbq9argjp6bl1019hxf28ywh";
     crates = [
       {
@@ -353,9 +379,9 @@
   {
     name = "librust-proxmox-network-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "0d7cde29e7502082fce836362b1dffa217b99cbb";
-
-    sha256 = "18g8wi47jbbzv5vqi6hay27g01w07ai5lbi7smb6cf92n5g01w3b";
+    rev = "55ecc70c85986dd7d692a42284a96f977ff732b6";
+    
+    sha256 = "10j35q04ma464glxlmh7pvlnk1ysnk71kvda4k9a5hvd4sfmns36";
     crates = [
       {
         name = "proxmox-network-api";
@@ -364,11 +390,24 @@
     ];
   }
   {
+    name = "librust-proxmox-network-types-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "b2e044225ba078a892e80405f424f25f9518417b";
+    
+    sha256 = "1mm6lfnrji5gxlsa591gswcjdn5wh3g48f84d7n6lh42g5ibb3ks";
+    crates = [
+      {
+        name = "proxmox-network-types";
+        path = "proxmox-network-types";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-notify-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "a73841292a19b7ceb0318a9092ee1b7cac4c7006";
-
-    sha256 = "0h3mamnpprqkgn8bjb82pbi89hxknbxp0qcyv83hqk774svm77ix";
+    rev = "52b04982627911d4d7255bd25c78d7eb4d695bcf";
+    
+    sha256 = "1xaamw59agm1dcphz2hpl46x8xpavl8vjjnjzrkqzm67vh3zrshp";
     crates = [
       {
         name = "proxmox-notify";
@@ -377,11 +416,24 @@
     ];
   }
   {
+    name = "librust-proxmox-oci-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "0ae01a3d97941a8919fd728a211fb5814a6cec56";
+    
+    sha256 = "07fa33hikkf920rkdpk9vn0f3y9dgxf06chq0083zpz6zngjp9xp";
+    crates = [
+      {
+        name = "proxmox-oci";
+        path = "proxmox-oci";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-openid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "2dcdb435ec4b123dbca5f3d81886174c4c831989";
-
-    sha256 = "1i8408pzh5ldgimrv4fnndjlpbdwpnamx8mif94hwmxdkwi72s2n";
+    rev = "cddc6b525b92cea57694297fba678d49e348ba8a";
+    
+    sha256 = "1wkrs2xid9wfzv4i9r0kpcdrxhr8rhlp5hwyzbjvm2vi50h0d0jl";
     crates = [
       {
         name = "proxmox-openid";
@@ -393,7 +445,7 @@
     name = "librust-proxmox-product-config-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "d42d5038bc4998200d18c9d190b9b013d6522722";
-
+    
     sha256 = "1dsjziab9d8lm34fdd4fh2rjm6xz3fas6rwaya0gzc8dwmvn4ar2";
     crates = [
       {
@@ -406,7 +458,7 @@
     name = "librust-proxmox-resource-scheduling-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "5625354accdede10680287257d959e135b6742d0";
-
+    
     sha256 = "02bh82r3yccvgydvpi23k8nh0r2wn3503ji0z35fl5npb7ayzvsk";
     crates = [
       {
@@ -418,9 +470,9 @@
   {
     name = "librust-proxmox-rest-server-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "9dd397f84e23f1eb87046ff394fdf3df824376ea";
-
-    sha256 = "0h2wrg5955rih2441s4vlb7bcyscxc34va2d1i4ik8j616pxli0p";
+    rev = "391df828cfe5d0918913ebbb172b11a3d9598d14";
+    
+    sha256 = "0rc55hxjgi1l4g28lgp02v0f49knfajr1b9w931xv71nj0yxa82n";
     crates = [
       {
         name = "proxmox-rest-server";
@@ -431,9 +483,9 @@
   {
     name = "librust-proxmox-router-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "35c28da99fc02a8f9de3e010ccac3dc8167e8c31";
-
-    sha256 = "1a51xxz9l5gs02dyxhx1zcc1733j543n04xnx5557cxbyfcj5d9h";
+    rev = "cd920ed03ba6fa8210d4366e64742c89aa60ed64";
+    
+    sha256 = "06bvp82n6f5a8r58f9r51v9zilcv2489r1mi90ksxfng10v0pr12";
     crates = [
       {
         name = "proxmox-router";
@@ -442,11 +494,24 @@
     ];
   }
   {
+    name = "librust-proxmox-s3-client-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "de54ac7f42817a66a9724e393d470a5730de5e72";
+    
+    sha256 = "0q6lambyhfbkr4yv61v1j4l5x61bb3lia2mh2rgc4l9fksnaxgg2";
+    crates = [
+      {
+        name = "proxmox-s3-client";
+        path = "proxmox-s3-client";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-schema-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "997bcc2f9d96f2e9835673f3a80846d60a908aed";
-
-    sha256 = "1ldkh7z1lja4qzni2kwc2dbr0gm7cd0lcq9brxlq5i932rwvcpvv";
+    rev = "ed34cf12938cf9f78162ba5a2d98956b416a8883";
+    
+    sha256 = "0qk5jzlp8ks9gpaya88hs1v7slrhswxbwd023kkc8wg92bb1g7ir";
     crates = [
       {
         name = "proxmox-schema";
@@ -455,11 +520,24 @@
     ];
   }
   {
+    name = "librust-proxmox-sdn-types-dev";
+    url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
+    rev = "17af874c77f767323a0cf19ef1345f9910ccb5ff";
+    
+    sha256 = "187g9sy767qh8hzmj3ydcys5b3i2di2dnbvrpkzm0h0g3xskk2q0";
+    crates = [
+      {
+        name = "proxmox-sdn-types";
+        path = "proxmox-sdn-types";
+      }
+    ];
+  }
+  {
     name = "librust-proxmox-section-config-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "61b5788a639e3e74f85666f8c240d6b37acdf9fa";
-
-    sha256 = "0w8zggdf9dcfbk8f11ipq50z0id9fab0jadsrjn8vw1w5gh5rwf9";
+    rev = "2a375fa97ea361fb7b2c283b754478a1a6e791c7";
+    
+    sha256 = "1f3rlcf8w0zfdn3znah79k3f55rqjvrg2k0w02klsr7knqv8s050";
     crates = [
       {
         name = "proxmox-section-config";
@@ -470,9 +548,9 @@
   {
     name = "librust-proxmox-sendmail-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "f03e6651032acce45246f49a6bc6bc1f0794244b";
-
-    sha256 = "098px04lajing8pypax7lqardafdzsm9ikpg8qdcwx7p1qhsnjvy";
+    rev = "13340ae4452f8e07d2b35769233914ab8cb84192";
+    
+    sha256 = "1yafbqafwv7bjgc414p6vm6hiy0fwb53sh9wsp2l3m83i5ixx464";
     crates = [
       {
         name = "proxmox-sendmail";
@@ -483,9 +561,9 @@
   {
     name = "librust-proxmox-serde-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "521ebf5bf0160f7a8843d363073ebb9e21d101c1";
-
-    sha256 = "0mwsdg7j6xa1nlvgnqqlpw49vazs399f2m3c4g5p08hx39wvlhzv";
+    rev = "84ee8f4e5d825625a3d957b341f5c55cca1e4b32";
+    
+    sha256 = "06ygg8j5h466k0hvbbf0323abjcv7j72qxn2vkvfxxb7dygagwsd";
     crates = [
       {
         name = "proxmox-serde";
@@ -497,7 +575,7 @@
     name = "librust-proxmox-shared-cache-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "d23c49fe82b9bd7a15c7c58585be443116f3045a";
-
+    
     sha256 = "151czqr9v08vqp2jfgdbc79fbq5v7jpyhifzn244zrvmklpgsmiv";
     crates = [
       {
@@ -510,7 +588,7 @@
     name = "librust-proxmox-shared-memory-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "eb1116c1e3fd27e391a9dde487eabc673368a6c5";
-
+    
     sha256 = "0gccrgy2qlggqwhb42zkypn8bdg05xxd62g4gaz9mzc1wby9bk34";
     crates = [
       {
@@ -522,9 +600,9 @@
   {
     name = "librust-proxmox-simple-config-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "c273e86e0cef266e11ccfe2d2522e79173ffdaff";
-
-    sha256 = "1zma7rj7ksl0n5msnwbi195kkxchj3ax9h5fg3q8v5v70dmv8vv9";
+    rev = "35587a12af4197fb8243c9239a27302d2fc283b8";
+    
+    sha256 = "1f81702jxdi9mxbrix4fsq71aw5nmj41myi6y45cimx1lm49gpdg";
     crates = [
       {
         name = "proxmox-simple-config";
@@ -536,7 +614,7 @@
     name = "librust-proxmox-sortable-macro-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "a1766995b589c5668a7f9d4f0b15e6fbe32b6a36";
-
+    
     sha256 = "1p1q732ni8cmx3hckac01q93y1bq2qrpr0zgigwq095gg6xik680";
     crates = [
       {
@@ -548,9 +626,9 @@
   {
     name = "librust-proxmox-subscription-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "5f641e5a99e89d52ccdde500d79ce2c0d6dea71a";
-
-    sha256 = "1s249m4z776czzbhi0s4a8vshh2p7pw305iqxfsjnk06ii6zghnf";
+    rev = "7c2a07e69b42b73e149489027409932af623ef94";
+    
+    sha256 = "1mkm2wvpr7nn03b9f2kxlylwi2sf8nyynk3kjy10aam8x1kdnxa7";
     crates = [
       {
         name = "proxmox-subscription";
@@ -562,7 +640,7 @@
     name = "librust-proxmox-sys-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "4919e03d9bd2b6b0be914667eedcff81e727ab12";
-
+    
     sha256 = "1990ywrlzd9jiliskcha96kmqbdlw6bcwixyjsdnm8kpnc8rrxzk";
     crates = [
       {
@@ -574,9 +652,9 @@
   {
     name = "librust-proxmox-syslog-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "b79913168ac606619b4934a614dcfc83cc6833ee";
-
-    sha256 = "1q3z4csi2l2m1bppk9rv7hmf9mlwsvfa7a7c3iil0c9ws3767x0d";
+    rev = "7440ea15b3a70fe4b00a4986957dfd031053ac14";
+    
+    sha256 = "08ysn6z0cfcic9w0xcpm9a590ry4dd60n3gs2c9nj5n81gz06rr8";
     crates = [
       {
         name = "proxmox-syslog-api";
@@ -588,7 +666,7 @@
     name = "librust-proxmox-systemd-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "fb3e8ca768c5c815fc55ca78e095df35a1c06d78";
-
+    
     sha256 = "1lblv6sw4rrwf1xha3hz727mwas90zqykx9nwrw60s0sabw5pyic";
     crates = [
       {
@@ -600,9 +678,9 @@
   {
     name = "librust-proxmox-tfa-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3ee2c779f44d60b9698031f1869dd6f9fe984659";
-
-    sha256 = "1xbq98ccjmd10cjl7v7hnhp9q8gjvzja0hzncmwhahna6agd5708";
+    rev = "320f2f0c600b03829bfe534ea4bed4730122dad0";
+    
+    sha256 = "01dnv4jcagpv8vkajm98l1bml3z8w5sj2p214y94l4915j7991xm";
     crates = [
       {
         name = "proxmox-tfa";
@@ -613,9 +691,9 @@
   {
     name = "librust-proxmox-time-api-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "3d8d38799e403e069679aa942565d95bc65b48fe";
-
-    sha256 = "0ga8zp7kqvlzvjal9zgwi4qx7nj0grjg0a9xb9ll6anx08si0jac";
+    rev = "3db314886689109607ff9756fff04c4710e2c410";
+    
+    sha256 = "072f7b3pabkkhf7v349n2ns99xhqlamzs7wvhipgbz354rv62q42";
     crates = [
       {
         name = "proxmox-time-api";
@@ -627,7 +705,7 @@
     name = "librust-proxmox-time-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "a79ccc19071ad69ee419a58f38577216182ffbaa";
-
+    
     sha256 = "1kl0syqwf59654i43hm4ca0l124wixl43mlvhhj9p2j81iydyyzn";
     crates = [
       {
@@ -639,9 +717,9 @@
   {
     name = "librust-proxmox-uuid-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
-    rev = "391412712c4dd6f86157eb0c3767ef6e36750896";
-
-    sha256 = "sha256-c3Z7LveHM34DNlEcVpFFgP8sQFIDYjPsxO6wdK2RdgE=";
+    rev = "aced6d2b7d8c47e1a5825d825ac988eac7d90c8a";
+    
+    sha256 = "01famhymykh5l99iq5gg6rifbfn8gwxpi4zlpnihbiv83kqx6xvc";
     crates = [
       {
         name = "proxmox-uuid";
@@ -652,9 +730,9 @@
   {
     name = "librust-proxmox-ve-config-dev";
     url = "git://git.proxmox.com/git/proxmox-ve-rs.git";
-    rev = "fcfed30d860966320753752e33853981362d616e";
-
-    sha256 = "0gvwkyz2s8111rymg7ccqrfhx652y3y6i2bq1xys0yg2myy913zw";
+    rev = "a1cfdba949de09c7beea597bcae76431312b89d8";
+    
+    sha256 = "1ky9hlh1ah9aq73jdskmbwzwq5fjpfqjdkq69s1310qmjfkik6mw";
     crates = [
       {
         name = "proxmox-ve-config";
@@ -666,7 +744,7 @@
     name = "librust-proxmox-worker-task-dev";
     url = "git://git.proxmox.com/git/proxmox.git";
     rev = "b7292443a12b2f0c43b5d4e9bee6334e0e6241ff";
-
+    
     sha256 = "1q0pvx1vrhpva2n7ykvpzgch735c7vhg5lvb4n6946l33dn0cyna";
     crates = [
       {
@@ -676,10 +754,62 @@
     ];
   }
   {
+    name = "librust-proxmox-yew-comp-dev";
+    url = "git://git.proxmox.com/git/ui/proxmox-yew-comp.git";
+    rev = "8ef4be030aefaf5b831b5913da65b4a52ad39dfc";
+    
+    sha256 = "1s4kslc9ilmcny9bb5lvjf7h2rahzalajc9n7n87fqz5215f1qrh";
+    crates = [
+      {
+        name = "proxmox-yew-comp";
+        path = ".";
+      }
+    ];
+  }
+  {
+    name = "librust-pve-api-types-dev";
+    url = "git://git.proxmox.com/git/proxmox.git";
+    rev = "54299e63614cc570ff871af88091bb907225fd25";
+    
+    sha256 = "1fkhahp92p8nr1x25aqcwyhb3v4a8x08sr0vwh7sgkpxr9s7h3yz";
+    crates = [
+      {
+        name = "pve-api-types";
+        path = "pve-api-types";
+      }
+    ];
+  }
+  {
+    name = "librust-pwt-dev";
+    url = "git://git.proxmox.com/git/ui/proxmox-yew-widget-toolkit.git";
+    rev = "10b2149f4372bf38a2268f89c12302228ccd1031";
+    
+    sha256 = "0423zhlvcngfzakzac42zvg54a338rkps0f6379qisalimf0y8ik";
+    crates = [
+      {
+        name = "pwt";
+        path = ".";
+      }
+    ];
+  }
+  {
+    name = "librust-pwt-macros-dev";
+    url = "git://git.proxmox.com/git/ui/proxmox-yew-widget-toolkit.git";
+    rev = "23d4a1627b2cd89e97cba561a0824a2891b41452";
+    
+    sha256 = "0zjzh1iclb6gcidn5csxbbgdsz84s9mdgr4bv636ppchfa5j2vjv";
+    crates = [
+      {
+        name = "pwt-macros";
+        path = "pwt-macros";
+      }
+    ];
+  }
+  {
     name = "librust-pxar-dev";
     url = "git://git.proxmox.com/git/pxar.git";
     rev = "993c66fcb8819770f279cb9fb4d13f58f367606c";
-
+    
     sha256 = "1bqfdq15kq45wrqmsh559ijbv48k73fjca5l4198mflgii6f942p";
     crates = [
       {


### PR DESCRIPTION
This PR bumps the project to nixos 25.11 (latest stable), and bumped all Proxmox packages to the latest stable. This PR serves the same purpose of #207 (apologize if I incorrectly assumed that is not being actively worked on).

Highlights:

* Bumped nixpkgs reference to `nixos-25.11`
* Bumped existing packages to match the latest Proxmox VE 9.1 release
* Fixed doc generation of pve-docs

Tested basic functionality:

<img width="1421" height="907" alt="image" src="https://github.com/user-attachments/assets/cde96abd-2f48-468c-9f8c-e73e63dc7c48" />

