### PR TITLE
pve-qemu: enable FUSE block export support

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -5,7 +5,13 @@
 let
   callPackage = pkgs.lib.callPackageWith (pkgs // ours);
 
+  # Patch swtpm for FUSE export support, using a separate nixpkgs import to avoid recursion
+  basePkgs = import pkgs.path { inherit (pkgs) system config; };
+
   ours = {
+    swtpm = basePkgs.swtpm.overrideAttrs (old: {
+      patches = (old.patches or [ ]) ++ [ ./pve-qemu-server/swtpm-fuse.patch ];
+    });
     authenpam = callPackage ./perl-modules/authenpam { };
     datadumper = callPackage ./perl-modules/datadumper { };
     digestsha = callPackage ./perl-modules/digestsha { };

--- a/pkgs/pve-qemu-server/swtpm-fuse.patch
+++ b/pkgs/pve-qemu-server/swtpm-fuse.patch
@@ -1,0 +1,57 @@
+diff --git a/src/swtpm_setup/swtpm_backend_file.c b/src/swtpm_setup/swtpm_backend_file.c
+index a0d0f4d..d4ca2c5 100644
+--- a/src/swtpm_setup/swtpm_backend_file.c
++++ b/src/swtpm_setup/swtpm_backend_file.c
+@@ -57,36 +57,28 @@ static int check_access(void *state,
+     return ret == 0 || errno == ENOENT ? 0 : 1;
+ }
+
+-/* Delete state from file: if regular file, unlink, if blockdev, zero header so
+- * swtpm binary will treat it as a new instance. */
++/* Delete state from file: zero header so swtpm binary will treat it as a new
++ * instance. */
+ static int delete_state(void *state) {
+     const struct file_state *fstate = (struct file_state*)state;
+     int fd;
+
+-    if (fstate->is_blockdev) {
+-        char zerobuf[8] = {0}; /* swtpm header has 8 byte */
+-        fd = open(fstate->path, O_WRONLY);
+-        if (fd < 0) {
+-            logerr(gl_LOGFILE, "Couldn't open file for clearing %s: %s\n",
+-                   fstate->path, strerror(errno));
+-            return 1;
+-        }
+-        /* writing less bytes than requested is bad, but won't set errno */
+-        errno = 0;
+-        if (write(fd, zerobuf, sizeof(zerobuf)) < (long)sizeof(zerobuf)) {
+-            logerr(gl_LOGFILE, "Couldn't write file for clearing %s: %s\n",
+-                   fstate->path, strerror(errno));
+-            close(fd);
+-            return 1;
+-        }
++    char zerobuf[8] = {0}; /* swtpm header has 8 byte */
++    fd = open(fstate->path, O_WRONLY);
++    if (fd < 0) {
++        logerr(gl_LOGFILE, "Couldn't open file for clearing %s: %s\n",
++               fstate->path, strerror(errno));
++        return 1;
++    }
++    /* writing less bytes than requested is bad, but won't set errno */
++    errno = 0;
++    if (write(fd, zerobuf, sizeof(zerobuf)) < (long)sizeof(zerobuf)) {
++        logerr(gl_LOGFILE, "Couldn't write file for clearing %s: %s\n",
++               fstate->path, strerror(errno));
+         close(fd);
+-    } else {
+-        if (unlink(fstate->path)) {
+-            logerr(gl_LOGFILE, "Couldn't unlink file for clearing %s: %s\n",
+-                   fstate->path, strerror(errno));
+-            return 1;
+-        }
++        return 1;
+     }
++    close(fd);
+
+     return 0;
+ }

--- a/pkgs/pve-qemu/default.nix
+++ b/pkgs/pve-qemu/default.nix
@@ -8,6 +8,7 @@
   meson,
   cacert,
   git,
+  fuse3,
   pve-update-script,
 }:
 
@@ -60,7 +61,8 @@ in
 
   sourceRoot = "${src.name}/qemu";
 
-  buildInputs = old.buildInputs ++ [ proxmox-backup-qemu ];
+  buildInputs = old.buildInputs ++ [ proxmox-backup-qemu fuse3 ];
+  configureFlags = old.configureFlags ++ [ "--enable-fuse" ];
   propagatedBuildInputs = [ proxmox-backup-qemu ];
 
   preBuild = ''


### PR DESCRIPTION
Enable FUSE support in pve-qemu by adding fuse3 to buildInputs and --enable-fuse to configureFlags. This is required for features like storing TPM state as qcow2 files.

Also patch swtpm to zero the file header instead of unlinking when clearing state, since FUSE exports cannot be unlinked.

Fixes #221