### PR TITLE
pve-common: pin Crypt::OpenSSL::RSA to 0.33

### DIFF
--- a/pkgs/pve-common/default.nix
+++ b/pkgs/pve-common/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchgit,
+  fetchurl,
   bash,
   coreutils,
   diffutils,
@@ -21,11 +22,19 @@
 }:
 
 let
+  cryptOpenSSLRSA = perl540.pkgs.CryptOpenSSLRSA.overrideAttrs (_old: {
+    version = "0.33";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/T/TO/TODDR/Crypt-OpenSSL-RSA-0.33.tar.gz";
+      hash = "sha256-xpsIlwnB+UE/s9MmzpdVdK0JXEQG8HnfqlYjGurpjXA=";
+    };
+  });
+
   perlDeps = with perl540.pkgs; [
     AnyEvent
     Carp
     Clone
-    CryptOpenSSLRSA
+    cryptOpenSSLRSA
     CryptOpenSSLRandom
     PathTools
     DataDumper

--- a/pkgs/pve-common/default.nix
+++ b/pkgs/pve-common/default.nix
@@ -26,7 +26,7 @@ let
     version = "0.33";
     src = fetchurl {
       url = "mirror://cpan/authors/id/T/TO/TODDR/Crypt-OpenSSL-RSA-0.33.tar.gz";
-      hash = "sha256-xpsIlwnB+UE/s9MmzpdVdK0JXEQG8HnfqlYjGurpjXA=";
+      hash = "sha256-vb5jD21vVAMldGrZmXcnKshmT/gb0Z8K2rptb0Xv2GQ=";
     };
   });
 


### PR DESCRIPTION
Fixes #217

Crypt::OpenSSL::RSA 0.35 (from nixpkgs) causes ISO uploads to fail with `Error '0' occurred while receiving the document` and `illegal or unsupported padding mode` errors in pveproxy logs.

Pinning to 0.33 resolves the issue, as confirmed in the issue thread.