### PR TITLE
Bump to latest Proxmox VE 9.1.6 packages

### DIFF
--- a/pkgs/linstor-api-py/default.nix
+++ b/pkgs/linstor-api-py/default.nix
@@ -7,14 +7,14 @@
 
 python310.pkgs.buildPythonPackage rec {
   pname = "linstor-api-py";
-  version = "1.26.1";
+  version = "1.27.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "LINBIT";
     repo = "linstor-api-py";
     rev = "v${version}";
-    hash = "sha256-AQMK838P+l0BKaCSOO/+FxNVN3PZsC05n5zgut86RZs=";
+    hash = "sha256-5DKwrylidnIA5OUVIPHkXAQoS/XM4YMN65WDBI3SJME=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/linstor-client/default.nix
+++ b/pkgs/linstor-client/default.nix
@@ -8,15 +8,22 @@
 
 python310.pkgs.buildPythonApplication rec {
   pname = "linstor-client";
-  version = "1.26.1";
+  version = "1.27.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "LINBIT";
     repo = "linstor-client";
     rev = "v${version}";
-    hash = "sha256-QEP3YLmBwvNvUcU/OLPgkb2O9tguOngYVj0HRhIGd0A=";
+    hash = "sha256-k/b/5fwwP+3wsnlFvDmACdmEokFTQjoTLjzO8zojhp8=";
   };
+
+  # Upstream uses distro package names in install_requires (e.g. python3-setuptools)
+  # instead of PyPI names (e.g. setuptools), since they distribute via Debian/RPM.
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail '"python3-setuptools"' '"setuptools",'
+  '';
 
   nativeBuildInputs = [
     python310.pkgs.setuptools

--- a/pkgs/linstor-proxmox/default.nix
+++ b/pkgs/linstor-proxmox/default.nix
@@ -19,13 +19,13 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "linstor-proxmox";
-    version = "8.1.3";
+    version = "8.2.0";
 
     src = fetchFromGitHub {
       owner = "LINBIT";
       repo = "linstor-proxmox";
       rev = "v${version}";
-      hash = "sha256-edD77DlsYozs2sgLykZkFOYTLnkbG9dGgt/Q/94Jwnw=";
+      hash = "sha256-nvVN6jEiwo2oJaca6hE3T1TW/zpZNNy4WaCNgrQcUL0=";
     };
 
     makeFlags = [

--- a/pkgs/markedjs/default.nix
+++ b/pkgs/markedjs/default.nix
@@ -7,16 +7,16 @@
 
 buildNpmPackage rec {
   pname = "markedjs";
-  version = "16.4.1";
+  version = "17.0.4";
 
   src = fetchFromGitHub {
     owner = "markedjs";
     repo = "marked";
     rev = "v${version}";
-    hash = "sha256-zlf8COkHTOqpyZp7FbhJocvBqmQ4ZYkT6IVMGr9IEjk=";
+    hash = "sha256-/dO6/z76DIVGBhOifRpmw1BCdSZYHRynGh1C/O8DYWI=";
   };
 
-  npmDepsHash = "sha256-4FEzBjBxSaM/4qFCGrUoZa44K/RcA8f7S6j6KgFusik=";
+  npmDepsHash = "sha256-dko5NqFqDMa5ovizwOAlRMTdMe+Lb03u8UUMei8K4rA=";
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--flake" ]; };
 

--- a/pkgs/proxmox-widget-toolkit/default.nix
+++ b/pkgs/proxmox-widget-toolkit/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   pname = "proxmox-widget-toolkit";
-  version = "5.1.5";
+  version = "5.1.8";
 
   src = fetchgit {
     url = "git://git.proxmox.com/git/proxmox-widget-toolkit.git";
-    rev = "e0798f947fb727ce57f3423e782465a3c9115cfe";
-    hash = "sha256-wXHVgWnq/HUDJ3O6Jkgk521+AQwd9cLR4StACGO6buc=";
+    rev = "a5d03fff8f116c720e68394f7d6fbd41afe3e5bc";
+    hash = "sha256-b16nK3GYZXa/+LGi596m7lOiNF7ifmPHBg27qfqAzx8=";
   };
 
   sourceRoot = "${src.name}/src";

--- a/pkgs/pve-common/default.nix
+++ b/pkgs/pve-common/default.nix
@@ -72,12 +72,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-common";
-    version = "9.1.4";
+    version = "9.1.7";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "404a109680bd147766e39b8fda482e26b5e97b2c";
-      hash = "sha256-6m+uWPCvBmMKj/75zqZ70Ip7GWKW4nMfuIoga2n2500=";
+      rev = "9c1d4f469b8baaaa1cb73c335d2be08925142d1a";
+      hash = "sha256-v28wjqVX3iviI3Ngb8PZqz3tlMAxshyu/kSfeJwrYxw=";
     };
 
     sourceRoot = "${src.name}/src";
@@ -86,8 +86,6 @@ perl540.pkgs.toPerlModule (
       (replaceVars ./0001-ss_fix_path.patch {
         sspath = "${iproute2}/bin/";
       })
-
-      ./0002-mknod-mknodat.patch
 
       (replaceVars ./0003-pci-id-path.patch {
         pciutils = "${pciutils}";

--- a/pkgs/pve-container/default.nix
+++ b/pkgs/pve-container/default.nix
@@ -18,12 +18,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-container";
-    version = "6.0.18";
+    version = "6.1.2";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "963730e937c5ec51d0618b9ff9d4e5f6687cb3a3";
-      hash = "sha256-tGp6SMgGWOa2945WqocoFZynJ1fB2nGZvEsCFpDlx+Q=";
+      rev = "3ecacddbda0f8998ad5a7d57a98b0914a4ef0f88";
+      hash = "sha256-ZvmPYvUIQpwrzr16kWuH5bbiafkfwqlIZvuRKWcRN9I=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-ha-manager/default.nix
+++ b/pkgs/pve-ha-manager/default.nix
@@ -28,12 +28,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-ha-manager";
-    version = "5.1.0";
+    version = "5.1.1";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "df1794d1c73ee06f61b025668e1287a5b6cca4e2";
-      hash = "sha256-67lt0k1egzNmr3HP8hS/KYs0Hg3TBPOvDmMV8Ia6WOY=";
+      rev = "1a8d8bcef1934a43d37344caf965c082e55d451c";
+      hash = "sha256-3QcgqBrHgAb7+iZHZ2hltH/hDABQTH8lCxp/fsYKbH0=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -65,12 +65,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-manager";
-    version = "9.1.4";
+    version = "9.1.6";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "5ac30304265fbd8e";
-      hash = "sha256-nx6FyDSktgA70uGZPdjDsKP82nXrftlZ/M9Anghq2kU=";
+      rev = "71482d1833ded40a";
+      hash = "sha256-kydLVhu7mXJRGp8baKUsWAoB6ZJ2DLs0IqdP+jaJtFs=";
     };
 
     patches = [

--- a/pkgs/pve-network/default.nix
+++ b/pkgs/pve-network/default.nix
@@ -32,12 +32,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-network";
-    version = "1.2.4";
+    version = "1.2.5";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/${pname}.git";
-      rev = "3d9449686cd4a3427dda3e3ef9430b7630c3555b";
-      hash = "sha256-AJpxwrpGiOJl4LCGQcHzfD7hzdJN+2giI5JkY4Xmhls=";
+      rev = "5893df09e5858e0f4afbbedb410ea9325dd55a17";
+      hash = "sha256-KLS0nlXFnXjy4sqOpADF5wo1fb2vOZKM8o7KEfvTWfg=";
     };
 
     sourceRoot = "${src.name}/src/PVE";

--- a/pkgs/pve-qemu-server/default.nix
+++ b/pkgs/pve-qemu-server/default.nix
@@ -59,12 +59,12 @@ in
 perl540.pkgs.toPerlModule (
   stdenv.mkDerivation rec {
     pname = "pve-qemu-server";
-    version = "9.1.3";
+    version = "9.1.4";
 
     src = fetchgit {
       url = "git://git.proxmox.com/git/qemu-server.git";
-      rev = "e781d9713fb3d45a523fe14db6cd99ac60bbfbb5";
-      hash = "sha256-n5B9qklDXiwYg2uGQbCmkjwaC7xlC3MVL+U2uxB9Shw=";
+      rev = "29ea3d0c10b2cd8b426a0a2f8f4dd5c90929be39";
+      hash = "sha256-cxX+D2g9FayzI4zdYXe/924qedyKfOfD9+xJG+LvMxI=";
     };
 
     sourceRoot = "${src.name}/src";

--- a/pkgs/pve-qemu/default.nix
+++ b/pkgs/pve-qemu/default.nix
@@ -17,13 +17,13 @@ let
 in
 (qemu.overrideAttrs (old: rec {
   pname = "pve-qemu";
-  version = "10.1.2-5";
+  version = "10.1.2-7";
 
   src =
     (fetchgit {
       url = "git://git.proxmox.com/git/pve-qemu.git";
-      rev = "de7f8fe356c7b1d346c3c15c971f7a0dcd11e70e";
-      hash = "sha256-gDKhnM0Rf20Fd82VQhrCDrrxB9e/ZCDYYpDOVOoxcmE=";
+      rev = "a7c7a6b2b1aa75360d914b252dfcb05506ce590b";
+      hash = "sha256-TE7FgMTzzlbuUgP/04UC0FzazNRfpFEbHfSUVXrT08U=";
       fetchSubmodules = true;
 
       # Download subprojects managed by meson

--- a/pkgs/unifont/default.nix
+++ b/pkgs/unifont/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "unifont";
-  version = "15.1.05";
+  version = "17.0.03";
 
   src = fetchurl {
     url = "mirror://gnu/unifont/unifont-${version}/unifont-${version}.tar.gz";
-    hash = "sha256-0nX1X0NYdQ4PhjBbkuh7iOszCqRsFfVT0u3wR/scI/o=";
+    hash = "sha256-miaqmt+o6x+RsM2bg+f5XqnhTG6FvnGqOrDfXLTmnDU=";
   };
 
   makeFlags = [


### PR DESCRIPTION
Tested locally:

<img width="1513" height="974" alt="image" src="https://github.com/user-attachments/assets/0638a1e8-6c50-4a50-97c7-f4c2fcbd286c" />

* pve-common: 9.1.4 -> 9.1.7
* pve-qemu: 10.1.2-5 -> 10.1.2-7
* unifont: 15.1.05 -> 17.0.03
* proxmox-widget-toolkit: 5.1.5 -> 5.1.8
* markedjs: 16.4.1 -> 17.0.4
* pve-container: 6.0.18 -> 6.1.2
* pve-network: 1.2.4 -> 1.2.5
* pve-ha-manager: 5.1.0 -> 5.1.1
* pve-qemu-server: 9.1.3 -> 9.1.4
* pve-manager: 9.1.4 -> 9.1.6
* linstor-api-py: 1.26.1 -> 1.27.1
* linstor-client: 1.26.1 -> 1.27.1
* linstor-proxmox: 8.1.3 -> 8.2.0
