### PR TITLE
fix: Broken pv* ops due to a postFixup typo

### DIFF
--- a/pkgs/pve-storage/default.nix
+++ b/pkgs/pve-storage/default.nix
@@ -94,7 +94,8 @@ perl540.pkgs.toPerlModule (
         -e "s|/sbin/blockdev|${util-linux}/bin/blockdev|" \
         -e "s|/sbin/lv|${lvm2.bin}/bin/lv|" \
         -e "s|/sbin/mkfs|${util-linux}/bin/mkfs|" \
-        -e "s|/sbin/pv|${lvm2.bin}/bin/vg|" \
+        -e "s|/usr/sbin/pvesm|$out/bin/pvesm|" \
+        -e "s|/sbin/pv|${lvm2.bin}/bin/pv|" \
         -e "s|/sbin/sgdisk|${gptfdisk}/bin/sgdisk|" \
         -e "s|/sbin/showmount|${nfs-utils}/bin/showmount|" \
         -e "s|/sbin/vg|${lvm2.bin}/bin/vg|" \
@@ -119,7 +120,6 @@ perl540.pkgs.toPerlModule (
         -re "s|/usr/s?bin/ceph|${ceph}/bin/ceph|" \
         -e "s|/usr/sbin/gluster|${glusterfs}/bin/gluster|" \
         -e "s|/usr/sbin/ietadm||" \
-        -e "s|/usr/sbin/pvesm|$out/bin/pvesm|" \
         -e "s|/usr/sbin/rpcinfo|${rpcbind}/bin/rpcinfo|" \
         -e "s|/usr/sbin/sbdadm||" \
         -e "s|/usr/sbin/smartctl|${smartmontools}/bin/smartctl|" \


### PR DESCRIPTION
This probably broke multiple flows, but the one I hit was:

When uploading iso to nodeA through nodeB API, nodeB calls to nodeA via
ssh and calls vgesm command to prepare storage. This broke iso upload
unless the storage target is the same as API target.
