### PR TITLE
declarative-vms: fix agent freeze-fs-on-backup key

### DIFF
--- a/modules/declarative-vms/options.nix
+++ b/modules/declarative-vms/options.nix
@@ -303,7 +303,7 @@ in
         types.submodule {
           options = {
             enabled = mkEnableOption "Enable or disable communication with the QEMU Guest Agent.";
-            freeze_fs_on_backup = mkEnableOption "Freeze file systems on backup.";
+            freeze-fs-on-backup = mkEnableOption "Freeze file systems on backup.";
             fstrim_cloned_disks = mkEnableOption "Enable or disable fstrim on cloned disks.";
             type = mkOption {
               type = types.enum [


### PR DESCRIPTION
Proxmox documents the QEMU guest agent option as a mixed-style
sub-option set: freeze-fs-on-backup uses hyphens, while
fstrim_cloned_disks uses underscores.

Keep the module key aligned with the documented API spelling so
nixmoxer can serialize it verbatim.

This patch doesn't attempt to maintain backwards compatibility because
this option never worked before.

See: https://pve.proxmox.com/pve-docs/qm.1.html
