### PR TITLE
fix: Enclose necessary packages for qmeventd VM reboot

### DIFF
--- a/pkgs/pve-ha-manager/default.nix
+++ b/pkgs/pve-ha-manager/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchgit,
   makeWrapper,
+  iproute2,
   perl5,
   pve-container,
   pve-firewall,
@@ -71,9 +72,12 @@ perl5.pkgs.toPerlModule (
     postFixup = ''
       for bin in $out/bin/*; do
         wrapProgram $bin \
-          --prefix PATH : ${lib.makeBinPath [ pve-qemu ]} \
+          --prefix PATH : "$out/bin:${lib.makeBinPath [
+            pve-qemu
+            iproute2
+          ]}" \
           --prefix PERL5LIB : $out/${perl5.libPrefix}/${perl5.version}
-      done      
+      done
     '';
 
     passthru.updateScript = pve-update-script { };

--- a/pkgs/pve-qemu-server/default.nix
+++ b/pkgs/pve-qemu-server/default.nix
@@ -82,6 +82,11 @@ perl5.pkgs.toPerlModule (
         -e "/modules-load.conf/d" \
         -e "s,usr/,,g"
 
+      # qmeventd should resolve qm from PATH instead of relying on /usr/sbin.
+      for file in $(grep -rl '/usr/sbin/qm' qmeventd bin PVE); do
+        sed -i -e 's!/usr/sbin/qm!qm!g' "$file"
+      done
+
       # Fix QEMU version check
       sed -i PVE/QemuServer/Helpers.pm -e "s/\[,\\\s\]//"
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,10 +1,15 @@
 { pkgs, extraBaseModules }:
 
 let
+  testLib = import ./lib.nix { inherit pkgs; };
   runTest =
-    module:
+    modulePath:
+    let
+      module = import modulePath;
+      resolvedModule = if builtins.isFunction module then module testLib else module;
+    in
     pkgs.testers.runNixOSTest {
-      imports = [ module ];
+      imports = [ resolvedModule ];
       globalTimeout = 5 * 60;
       extraBaseModules = {
         imports = builtins.attrValues extraBaseModules;
@@ -16,5 +21,6 @@ in
   # test-pve-ceph = runTest ./ceph.nix;
   test-pve-cluster = runTest ./cluster.nix;
   test-pve-linstor = runTest ./linstor.nix;
+  test-pve-reboot = runTest ./reboot.nix;
   test-pve-vm = runTest ./vm.nix;
 }

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+
+{
+  minimalIso = pkgs.fetchurl {
+    url = "https://releases.nixos.org/nixos/24.05/nixos-24.05.7139.bcba2fbf6963/nixos-minimal-24.05.7139.bcba2fbf6963-x86_64-linux.iso";
+    hash = "sha256-plre/mIHdIgU4xWU+9xErP+L4i460ZbcKq8iy2n4HT8=";
+  };
+}

--- a/tests/reboot.nix
+++ b/tests/reboot.nix
@@ -1,0 +1,47 @@
+{ minimalIso, ... }:
+
+{
+  name = "pve-reboot";
+
+  nodes.mypve = {
+    services.proxmox-ve = {
+      enable = true;
+      ipAddress = "192.168.1.1";
+      bridges = [ "vmbr0" ];
+    };
+
+    networking.bridges.vmbr0.interfaces = [ ];
+
+    virtualisation = {
+      additionalPaths = [ minimalIso ];
+      diskSize = 4096;
+      memorySize = 2048;
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("pveproxy.service")
+    machine.wait_for_unit("qmeventd.service")
+    assert "running" in machine.succeed("pveproxy status")
+
+    machine.succeed("mkdir -p /var/lib/vz/template/iso/")
+    machine.succeed("cp ${minimalIso} /var/lib/vz/template/iso/minimal.iso")
+
+    machine.wait_until_succeeds("ip link show vmbr0")
+
+    machine.succeed(
+      "qm create 200 --memory 512 --cores 1 --net0 virtio,bridge=vmbr0 -cdrom local:iso/minimal.iso",
+      "qm start 200"
+    )
+    machine.wait_until_succeeds("qm status 200 | grep -F 'status: running'")
+
+    machine.succeed("touch /run/qemu-server/200.reboot")
+    machine.succeed("kill -TERM $(cat /run/qemu-server/200.pid)")
+
+    machine.wait_until_succeeds(
+      "journalctl -u qmeventd.service -b --no-pager | grep -F 'Restarting VM 200'"
+    )
+    machine.wait_until_succeeds("qm status 200 | grep -F 'status: running'")
+  '';
+}

--- a/tests/vm.nix
+++ b/tests/vm.nix
@@ -1,11 +1,4 @@
-{ pkgs, ... }:
-
-let
-  minimalIso = pkgs.fetchurl {
-    url = "https://releases.nixos.org/nixos/24.05/nixos-24.05.7139.bcba2fbf6963/nixos-minimal-24.05.7139.bcba2fbf6963-x86_64-linux.iso";
-    hash = "sha256-plre/mIHdIgU4xWU+9xErP+L4i460ZbcKq8iy2n4HT8=";
-  };
-in
+{ minimalIso, ... }:
 
 {
   name = "pve-vm";


### PR DESCRIPTION
When qmeventd restores network for a rebooted VM, it calls to `ip`
commands, so `iproute2` has to be in the closure. Also, `/usr/sbin/qm`
was called instead of through a properly enclosed derivation.

Also, add a test case for VM reboot scenario.

Fixes #224
