### PR TITLE
misc: align userspace zfs utils with booted kernel module

### DIFF
--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -23,11 +23,10 @@ lib.mkIf cfg.enable {
       ];
       path = with pkgs; [
         btrfs-progs
-        zfs
         bashInteractive
         cdrkit
         swtpm
-      ];
+      ] ++ [ config.boot.zfs.package ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/pvedaemon start";
         ExecStop = "${cfg.package}/bin/pvedaemon stop";
@@ -135,9 +134,9 @@ lib.mkIf cfg.enable {
         "pve-guests.service"
         "pve-storage.target"
       ];
-      path = with pkgs; [
-        btrfs-progs
-        zfs
+      path = [
+        pkgs.btrfs-progs
+        config.boot.zfs.package
       ];
       serviceConfig = {
         ExecStartPre = [
@@ -157,9 +156,9 @@ lib.mkIf cfg.enable {
       description = "PVE Status Daemon";
       wants = [ "pve-cluster.service" ];
       after = [ "pve-cluster.service" ];
-      path = with pkgs; [
-        btrfs-progs
-        zfs
+      path = [
+        pkgs.btrfs-progs
+        config.boot.zfs.package
       ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/pvestatd start";

--- a/pkgs/linstor-server/default.nix
+++ b/pkgs/linstor-server/default.nix
@@ -21,7 +21,6 @@
   systemdMinimal,
   thin-provisioning-tools,
   util-linux,
-  zfs,
   writeScript,
 }:
 
@@ -81,6 +80,7 @@ let
       mkdir -p $out/lib/conf
       cp -r build/install/linstor-server/lib/* $out/lib/
       cp server/logback.xml $out/lib/conf/
+      # zfs/zpool resolved via /run/booted-system to match the loaded kmod.
       makeWrapper ${jre}/bin/java $out/bin/linstor-controller \
         --add-flags "-Xms32M -classpath $out/lib/conf:$out/lib/* com.linbit.linstor.core.Controller" \
         --prefix PATH : ${
@@ -98,9 +98,9 @@ let
             systemdMinimal
             thin-provisioning-tools
             util-linux
-            zfs
           ]
-        }
+        } \
+        --suffix PATH : /run/booted-system/sw/bin
 
       makeWrapper ${jre}/bin/java $out/bin/linstor-satellite \
         --add-flags "-Xms32M -classpath $out/lib/conf:$out/lib/* com.linbit.linstor.core.Satellite" \
@@ -119,9 +119,9 @@ let
             systemdMinimal
             thin-provisioning-tools
             util-linux
-            zfs
           ]
-        }
+        } \
+        --suffix PATH : /run/booted-system/sw/bin
     '';
 
     passthru.updateScript = writeScript "update-linstor-server" ''

--- a/pkgs/pve-storage/default.nix
+++ b/pkgs/pve-storage/default.nix
@@ -26,7 +26,6 @@
   smartmontools,
   targetcli-fb,
   util-linux,
-  zfs,
   posixstrptime,
   pve-update-script,
 }:
@@ -84,6 +83,7 @@ perl540.pkgs.toPerlModule (
       cp -rs ${linstor-proxmox}/lib $out
     '';
 
+    # zfs/zpool resolved via /run/booted-system to match the loaded kmod.
     postFixup = ''
       find $out -type f | xargs sed -i \
         -e "s|/bin/lsblk|${util-linux}/bin/lsblk|" \
@@ -98,8 +98,8 @@ perl540.pkgs.toPerlModule (
         -e "s|/sbin/sgdisk|${gptfdisk}/bin/sgdisk|" \
         -e "s|/sbin/showmount|${nfs-utils}/bin/showmount|" \
         -e "s|/sbin/vg|${lvm2.bin}/bin/vg|" \
-        -e "s|/sbin/zfs|${zfs}/bin/zfs|" \
-        -e "s|/sbin/zpool|${zfs}/bin/zpool|" \
+        -e "s|/sbin/zfs|/run/booted-system/sw/bin/zfs|" \
+        -e "s|/sbin/zpool|/run/booted-system/sw/bin/zpool|" \
         -e "s|/usr/bin/chattr|${e2fsprogs}/bin/chattr|" \
         -e "s|/usr/bin/cstream||" \
         -e "s|/usr/bin/file|${file}/bin/file|" \


### PR DESCRIPTION
## Motivation

`pkgs.zfs` is a top-level nixpkgs alias pinned to one OpenZFS version (currently `zfs_2_3` on `nixos-25.11`). It is **not** wired to `boot.zfs.package`, so on a host running e.g. `zfs_2_4` (matched against the loaded kernel module), all three places where proxmox-nixos references `pkgs.zfs` silently fall out of sync with the running kmod:

- `pve-storage` bakes `${pkgs.zfs}/bin/zfs` into Perl source via `postFixup`
- `linstor-server` bakes `${pkgs.zfs}` into both wrapper PATHs via `makeBinPath`
- `modules/proxmox-ve/manager.nix` puts `pkgs.zfs` on systemd PATH for `pvedaemon`, `pvescheduler`, `pvestatd`

The upstream `boot.zfs` assertion (`modulePackage.version == package.version`) only guards the NixOS-managed side; it does not see these consumers. Result: `pvedaemon` and friends shell out to a different ZFS userspace version than the kernel module they're talking to — an unsupported configuration that can cause undefined behavior, especially around features added in newer OpenZFS releases (e.g. raidz expansion in 2.4).

Inconsistent versions between zfs userspace utils and zfs kmod may affect send/recv, as seen in https://devblog.yvn.no/posts/zfsutils-linux-and-hwe-kernels/. 

## Approach

Mirror the [sanoid/syncoid pattern](https://github.com/NixOS/nixpkgs/pull/131118) already used in nixpkgs:

- **Packages** (`pve-storage`, `linstor-server`): resolve `zfs`/`zpool` against `/run/booted-system/sw/bin` at runtime. These are shell-out consumers (no libzfs linkage), so the binary closure stays cacheable and only the resolution is deferred.
- **NixOS module** (`manager.nix`): take `zfs` from `config.boot.zfs.package` directly, since the module has access to NixOS config.

Verified: with `boot.zfs.package = pkgs.zfs_2_4`, `pvedaemon.path` correctly resolves to `zfs-user-2.4.1` instead of the default `zfs-user-2.3.6`.

P.S. Not sure why tests timed out in CI, I am able to run them locally.
