### PR TITLE
Fix "Start at Boot" when using ZVols

### DIFF
--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -93,7 +93,7 @@ lib.mkIf cfg.enable {
         bashInteractive
         cdrkit
         swtpm
-      ];
+      ] ++ [ config.boot.zfs.package ];
       unitConfig = {
         RefuseManualStart = true;
         RefuseManualStop = true;


### PR DESCRIPTION
## Problem

When using zvols, VMs don't start on boot automatically.

The pve-guests systemd unit runs `pvesh ... startall` at boot to autostart VMs. 

PVE's ZFSPoolPlugin shells out to `zpool list` (and `zpool import` as fallback) via Perl IPC::Open3 when activating a zfspool-type storage. Without zfs on the unit's PATH, exec returns ENOENT and autostart fails with:

```
zfs error: open3: exec of zpool list -o name -H unsafe-pool failed: No such file or directory at /nix/store/w9zkg0bsnvf1s1nqmc95qf7qrqf6k73n-perl-5.40.0-env/lib/perl5/site_perl/5.40.0/PVE/Tools.pm line 434.

zfs error: open3: exec of zpool list -o name -H unsafe-pool failed: No such file or directory at /nix/store/w9zkg0bsnvf1s1nqmc95qf7qrqf6k73n-perl-5.40.0-env/lib/perl5/site_perl/5.40.0/PVE/Tools.pm line 434.

TASK ERROR: could not activate storage 'unsafe-vms', zfs error: open3: exec of zpool import -d /dev/disk/by-id/ -o cachefile=none unsafe-pool failed: No such file or directory at /nix/store/w9zkg0bsnvf1s1nqmc95qf7qrqf6k73n-perl-5.40.0-env/lib/perl5/site_perl/5.40.0/PVE/Tools.pm line 434. 
```

Manual VM starts work because they go through pvedaemon, which already has zfs on its path. The bug only surfaces at boot for hosts using zfspool-backed storage (e.g. zvols).

## The fix
Add ZFS to `pve-guests`, using `config.boot.zfs.package` to stay consistent with the pattern applied in #235 , which I also cherry picked to test locally.

**I tested this locally and it fixes the problem.**
