### PR TITLE
fix offline migration

### DIFF
--- a/modules/proxmox-ve/manager.nix
+++ b/modules/proxmox-ve/manager.nix
@@ -22,9 +22,10 @@ lib.mkIf cfg.enable {
         "pve-cluster.service"
       ];
       path = with pkgs; [
-        btrfs-progs
         bashInteractive
+        btrfs-progs
         cdrkit
+        pve-storage
         swtpm
       ] ++ [ config.boot.zfs.package ];
       serviceConfig = {

--- a/pkgs/pve-manager/default.nix
+++ b/pkgs/pve-manager/default.nix
@@ -35,7 +35,7 @@
   util-linux,
   system-sendmail,
   rsync,
-  busybox,
+  coreutils,
   cstream,
   lvm2,
   lxc,
@@ -174,7 +174,7 @@ perl540.pkgs.toPerlModule (
 
               ## dependencies of backup and restore
               bash
-              busybox
+              coreutils
               cstream
               lvm2
               lxc


### PR DESCRIPTION
this fixes 2 problems that occur during offline migration:
1: `pvedaemon.service` tries to run `pvesm` on the source end to initiate migration, but fails because its not in `$PATH`
2: it then runs `dd status=progress`, with the `busybox` `dd`, which doesnt understand the `progress` mode