### PR TITLE
declarative-vms: allow target node set via nixmoxer --node

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ First, configure the virtual machine settings using the options of the NixOS mod
   networking.hostName = "myvm";
 
   virtualisation.proxmox = {
-    node = "myproxmoxnode";
     iso = <derivation for your iso>;
     vmid = 101;
     memory = 4096;
@@ -225,8 +224,12 @@ verify_ssl=0
 Now you can bootstrap `myvm` using `nixmoxer`:
 
 ```console
-$ nix run github:SaumonNet/proxmox-nixos#nixmoxer -- [--flake] myvm
+$ nix run github:SaumonNet/proxmox-nixos#nixmoxer -- [--flake] [--node NODE] myvm
 ```
+
+The target node can be set with `virtualisation.proxmox.node` or selected at
+bootstrap time with `--node`. The command-line option takes precedence. At
+least one of them must be provided.
 
 `nixmoxer` will setup the VM on the Proxmox node and attach the specified iso. Instead of specified an iso, setting `autoInstall = true;` will automatically generate an iso that will automatically install the configuration to the VM being bootstrapped.
 

--- a/modules/declarative-vms/default.nix
+++ b/modules/declarative-vms/default.nix
@@ -18,8 +18,9 @@ with lib;
 
   options.virtualisation.proxmox = (import ./options.nix { inherit config lib; }).options // {
     node = mkOption {
-      type = types.str;
-      description = "The cluster node name.";
+      type = types.nullOr types.str;
+      default = null;
+      description = "The cluster node name. May instead be selected when running nixmoxer.";
     };
 
     name = mkOption {

--- a/pkgs/nixmoxer/main.py
+++ b/pkgs/nixmoxer/main.py
@@ -632,19 +632,26 @@ def authenticate_promox():
 
 @click.command()
 @click.option("--flake", is_flag=True)
+@click.option("--node", help="Proxmox cluster node on which to create the VM.")
 @click.argument("machine")
-def bootstrap(flake, machine):
+def bootstrap(flake, machine, node=None):
     """
     Bootstrap the NixOS configuration for a specific machine using Nix flake or non-flake.
 
     Args:
         flake (bool): A flag indicating whether to use the Nix flake system.
         machine (str): The name of the machine to bootstrap.
+        node (str): An optional deployment-time target node override.
     """
     proxmox = authenticate_promox()
     config = eval_config(machine, flake)
     config = json.loads(config)
-    node = config["node"]
+    node = node or config.get("node")
+    if not node:
+        raise click.ClickException(
+            "no target node configured; pass --node or set virtualisation.proxmox.node"
+        )
+    config["node"] = node
     config.pop("autoInstall", None)
 
     build_iso(machine, flake)


### PR DESCRIPTION
VMs can migrate between cluster members during their lifetime, so
declaring their "placement" via nix option - and requiring it to be set -
is prone to drift over time.

This change makes the node option not required, and adds a new --node
option to nixmoxer to specify initial VM placement.
